### PR TITLE
rfcomm: Configurable DLC task stack size

### DIFF
--- a/include/zephyr/bluetooth/rfcomm.h
+++ b/include/zephyr/bluetooth/rfcomm.h
@@ -33,6 +33,12 @@ enum {
 	BT_RFCOMM_CHAN_SPP,
 };
 
+#ifdef CONFIG_BT_RFCOMM_DLC_STACK_SIZE
+#define BT_RFCOMM_DLC_STACK_SIZE CONFIG_BT_RFCOMM_DLC_STACK_SIZE
+#else
+#define BT_RFCOMM_DLC_STACK_SIZE 256
+#endif
+
 struct bt_rfcomm_dlc;
 
 /** @brief RFCOMM DLC operations structure. */
@@ -96,7 +102,7 @@ struct bt_rfcomm_dlc {
 
 	/* Stack & kernel data for TX thread */
 	struct k_thread            tx_thread;
-	K_KERNEL_STACK_MEMBER(stack, 256);
+	K_KERNEL_STACK_MEMBER(stack, BT_RFCOMM_DLC_STACK_SIZE);
 };
 
 struct bt_rfcomm_server {

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -902,6 +902,13 @@ config BT_RFCOMM_L2CAP_MTU
 	help
 	  Maximum size of L2CAP PDU for RFCOMM frames.
 
+config BT_RFCOMM_DLC_STACK_SIZE
+	int "RFCOMM DLC task stack size"
+	depends on BT_RFCOMM
+	default 256
+	help
+	  RFCOMM DLC task stack size.
+
 config BT_HFP_HF
 	bool "Bluetooth Handsfree profile HF Role support [EXPERIMENTAL]"
 	depends on PRINTK


### PR DESCRIPTION
bug: v/46620

1. reserve XCPTCONTEXT_SIZE for vela