### PR TITLE
Fix: compiling warning

### DIFF
--- a/subsys/bluetooth/host/br.c
+++ b/subsys/bluetooth/host/br.c
@@ -1301,7 +1301,7 @@ int bt_br_write_local_name(const char *name)
 	}
 
 	name_cp = net_buf_add(buf, sizeof(*name_cp));
-	strncpy((char *)name_cp->local_name, name,
+	strlcpy((char *)name_cp->local_name, name,
 		sizeof(name_cp->local_name));
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LOCAL_NAME, buf, NULL);

--- a/subsys/bluetooth/host/ssp.c
+++ b/subsys/bluetooth/host/ssp.c
@@ -72,7 +72,7 @@ static int pin_code_reply(struct bt_conn *conn, const char *pin, uint8_t len)
 
 	bt_addr_copy(&cp->bdaddr, &conn->br.dst);
 	cp->pin_len = len;
-	strncpy((char *)cp->pin_code, pin, sizeof(cp->pin_code));
+	strlcpy((char *)cp->pin_code, pin, sizeof(cp->pin_code));
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_PIN_CODE_REPLY, buf, NULL);
 }


### PR DESCRIPTION
bug: v/51417

1. Fix compiling warning. Use strlcpy instead of strncpy.