### PR TITLE
Enhance Zephyr bluetooth GAP

### DIFF
--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -197,6 +197,73 @@ int bt_br_set_discoverable(bool enable);
 int bt_br_set_connectable(bool enable);
 
 /**
+ * @brief Set controller page scan activity.
+ *
+ * Page Scan is only performed when Page_Scan is enabled.
+ *
+ * @param interval Page scan interval in 0.625 ms units
+ *        Range: 0x0012 to 0x1000; only even values are valid.
+ * @param window Page scan window in 0.625 ms units
+ *        Range: 0x0011 to 0x1000.
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_write_page_scan_activity(uint16_t interval, uint16_t window);
+
+/**
+ * @brief Set controller inquiry scan activity.
+ *
+ * Inquiry Scan is only performed when Inquiry_Scan is enabled.
+ *
+ * @param interval Inquiry scan interval in 0.625 ms units
+ *        Range: 0x0012 to 0x1000; only even values are valid.
+ * @param window Inquiry scan window in 0.625 ms units
+ *        Range: 0x0011 to 0x1000.
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_write_inquiry_scan_activity(uint16_t interval, uint16_t window);
+
+/**
+ * @brief Set the inquiry Scan Type configuration parameter of the local
+ *        BR/EDR Controller.
+ *
+ * @param type Inquiry scan type.
+ * 		   0x00: Standard scan (default)
+ * 		   0x01: Interlaced scan
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_write_inquiry_scan_type(uint8_t type);
+
+/**
+ * @brief Set the page Scan Type configuration parameter of the local
+ *        BR/EDR Controller.
+ *
+ * @param type Page scan type.
+ *        0x00: Standard scan (default)
+ *        0x01: Interlaced scan
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_write_page_scan_type(uint8_t type);
+
+/**
+ * @brief Set the Class of Device configuration parameter of the local
+ *        BR/EDR Controller.
+ *
+ * @param local_cod Class of Device value.
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_set_class_of_device(uint32_t local_cod);
+
+/**
  * @}
  */
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -273,6 +273,28 @@ int bt_br_set_class_of_device(uint32_t local_cod);
  */
 int bt_br_write_local_name(const char *name);
 /**
+ * @brief Request remote device name callback.
+ *
+ * @param bdaddr Remote device address.
+ * @param name Remote device name.
+ * @param status Status of the request.
+ */
+typedef void (*bt_br_remote_name_req_cb_t)(const bt_addr_t *bdaddr, const char *name, uint8_t status);
+
+/**
+ * @brief Request remote device name.
+ *
+ * Remote Name Request is used to find out the name of the remote
+ * device without requiring an explicit ACL connection
+ *
+ * @param addr Remote device address.
+ * @param cb Callback to notify about remote device name.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_br_remote_name_request(const bt_addr_t *addr, bt_br_remote_name_req_cb_t cb);
+
+/**
  * @}
  */
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -264,6 +264,15 @@ int bt_br_write_page_scan_type(uint8_t type);
 int bt_br_set_class_of_device(uint32_t local_cod);
 
 /**
+ * @brief Set the local name of the BR/EDR Controller.
+ *
+ * @param name Local name of the BR/EDR Controller.
+ *
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully.
+ */
+int bt_br_write_local_name(const char *name);
+/**
  * @}
  */
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -272,6 +272,44 @@ int bt_br_set_class_of_device(uint32_t local_cod);
  *         already set. Zero if done successfully.
  */
 int bt_br_write_local_name(const char *name);
+
+/** Information about a br/edr bond with a remote device. */
+struct bt_bond_info_br {
+	bt_addr_t addr;
+	uint8_t   key_type;
+	uint8_t   key[16];
+};
+
+/**
+ * @brief Callback for iterating over all BR/EDR bond information.
+ *
+ * @param info Bond information.
+ * @param user_data Data passed to the iterator.
+ */
+void bt_foreach_bond_br(void (*func)(const struct bt_bond_info_br *info, void *user_data),
+			void *user_data);
+
+/**
+ * @brief Set BR/EDR bond information.
+ *
+ * @param info Bond information.
+ *
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error.
+ */
+int bt_set_bond_info_br(const struct bt_bond_info_br *info);
+
+/**
+ * @brief Get BR/EDR bond information.
+ *
+ * @param bdaddr Address of the remote device.
+ * @param info Bond information.
+ *
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error.
+ */
+int bt_get_bond_info_br(const bt_addr_t* bdaddr, struct bt_bond_info_br *info);
+
 /**
  * @brief Request remote device name callback.
  *

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -333,6 +333,18 @@ typedef void (*bt_br_remote_name_req_cb_t)(const bt_addr_t *bdaddr, const char *
 int bt_br_remote_name_request(const bt_addr_t *addr, bt_br_remote_name_req_cb_t cb);
 
 /**
+ * @brief Unpair with a br remote device.
+ *
+ * remove the bond information with the remote device in controller
+ * or settings.
+ *
+ * @param bdaddr Remote device address.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_br_unpair(bt_addr_t *bdaddr);
+
+/**
  * @}
  */
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -840,6 +840,8 @@ struct bt_security_info {
 
 /** Connection Info Structure */
 struct bt_conn_info {
+	/** Connection handle. */
+	uint16_t handle;
 	/** Connection Type. */
 	enum bt_conn_type type;
 	/** Connection Role. */

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2651,6 +2651,20 @@ int bt_conn_switch_role(struct bt_conn *conn, uint8_t role);
  */
 int bt_conn_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout);
 
+/** @brief Set link policy settings.
+ *
+ *  This function is used to set the link policy settings for a connection.
+ *
+ *  @param conn  Connection object.
+ *  @param policy Link policy settings.
+ *                Bit 0: Enable role switch.
+ *                Bit 1: Enable hold mode.
+ *                Bit 2: Enable sniff mode.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_set_link_policy_settings(struct bt_conn* conn, uint16_t policy);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -723,6 +723,29 @@ struct bt_conn *bt_conn_lookup_addr_le(uint8_t id, const bt_addr_le_t *peer);
  */
 const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn);
 
+#if defined(CONFIG_BT_CLASSIC)
+/** @brief Look up an existing BREDR acl connection by address.
+ *
+ *  Look up an existing connection based on the remote address.
+ *
+ *  The caller gets a new reference to the connection object which must be
+ *  released with bt_conn_unref() once done using the object.
+ *
+ *  @param peer Remote address.
+ *
+ *  @return Connection object or NULL if not found.
+ */
+struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
+
+/** @brief Get destination (peer) address of a br or sco connection.
+ *
+ *  @param conn Connection object.
+ *
+ *  @return Destination address.
+ */
+const bt_addr_t *bt_conn_get_dst_br(const struct bt_conn *conn);
+#endif /* CONFIG_BT_CLASSIC */
+
 /** @brief Get array index of a connection
  *
  *  This function is used to map bt_conn to index of an array of
@@ -1615,6 +1638,24 @@ struct bt_conn_le_cs_procedure_enable_complete {
  *  used for that instance.
  */
 struct bt_conn_cb {
+#if !defined(CONFIG_BT_CONN_REQ_AUTO_HANDLE)
+	/** @brief Query to proceed BR/EDR incoming connection or not.
+	 *
+	 *  On any incoming connection req this callback will be called for
+	 *  the application to decide whether to allow for the connection to
+	 *  continue.
+	 *
+	 *  As this callback is asynchronous, the application should call
+	 *  bt_conn_accept_acl_conn/bt_conn_reject_acl_conn to response value.
+	 *
+	 *  @param conn New connection object.
+	 *  @param link_type Link type.
+	 *  @param cod Device class.
+	 *
+	 */
+	void (*connect_req)(struct bt_conn *conn, uint8_t link_type, uint8_t *cod);
+#endif /* !defined(CONFIG_BT_CONN_REQ_AUTO_HANDLE) */
+
 	/** @brief A new connection has been established.
 	 *
 	 *  This callback notifies the application of a new connection.
@@ -2664,6 +2705,23 @@ int bt_conn_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout);
  *  @return  Zero for success, non-zero otherwise.
  */
 int bt_conn_set_link_policy_settings(struct bt_conn* conn, uint16_t policy);
+
+/** @brief Accept the acl connection.
+ *
+ *  @param conn  The connection of peer device to accept.
+ *
+ *  @return Zero for success, non-zero otherwise.
+ */
+int bt_conn_accept_acl_conn(struct bt_conn *conn);
+
+/** @brief Reject the acl connection.
+ *
+ *  @param conn  The connection of peer device to reject.
+ *  @param reason  Reject reason.
+ *
+ *  @return Zero for success, non-zero otherwise.
+ */
+int bt_conn_reject_acl_conn(struct bt_conn *conn, uint8_t reason);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2437,6 +2437,18 @@ struct bt_conn_auth_cb {
 
 /** Authenticated pairing information callback structure */
 struct bt_conn_auth_info_cb {
+#if defined(CONFIG_BT_CLASSIC)
+	/** @brief notify that bredr pairing link key generated.
+	 *
+	 *  The callback notifies the application that the link key has been
+	 *  generated during the pairing procedure.
+	 *
+	 *  @param conn Connection object.
+	 *  @param key Link key.
+	 *  @param key_type Link key type.
+	 */
+	void (*link_key_notify)(struct bt_conn *conn, uint8_t *key, uint8_t key_type);
+#endif
 	/** @brief notify that pairing procedure was complete.
 	 *
 	 *  This callback notifies the application that the pairing procedure

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1759,6 +1759,7 @@ struct bt_conn_cb {
 				      struct bt_conn_remote_info *remote_info);
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
 
+#if defined(CONFIG_BT_CLASSIC)
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 	/** @brief The connection mode change
 	 *
@@ -1770,6 +1771,16 @@ struct bt_conn_cb {
 	 */
 	void (*mode_changed)(struct bt_conn *conn, uint8_t mode, uint16_t interval);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
+	/** @brief The connection role change
+	 *
+	 *  This callback notifies the application controller role change
+	 *
+	 *  @param conn Connection object.
+	 *  @param role New role updated.
+	 */
+	void (*role_changed)(struct bt_conn *conn, uint8_t role);
+#endif /* CONFIG_BT_CLASSIC */
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 	/** @brief The PHY of the connection has changed.
@@ -2604,6 +2615,24 @@ int bt_conn_enter_sniff_mode(struct bt_conn *conn, uint16_t min_interval, uint16
  */
 int bt_conn_exit_sniff_mode(struct bt_conn *conn);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
+/** @brief Bt role discovery.
+ * 
+ *  @param conn  Connection object.
+ *  @param role  return role.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_role_discovery(struct bt_conn *conn, uint8_t *role);
+
+/** @brief Bt switch role.
+ *
+ *  @param conn  Connection object.
+ *  @param role  Switch role.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_switch_role(struct bt_conn *conn, uint8_t role);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2482,6 +2482,21 @@ struct bt_conn_auth_info_cb {
 	sys_snode_t node;
 };
 
+/**
+ * @brief Initiate pairing with a remote device.
+ *
+ * This function is used to initiate pairing with a remote device.
+ * The pairing process is asynchronous and the result of the pairing
+ * process is reported through the pairing_complete, if the connection
+ * not exists, setup the connection first.
+ *
+ * @param bdaddr Remote device address.
+ * @param security Security level to use.
+ *
+ * @return Valid connection object on success or NULL otherwise.
+ */
+struct bt_conn *bt_conn_pair_br(bt_addr_t *bdaddr, bt_security_t security);
+
 /** @brief Register authentication callbacks.
  *
  *  Register callbacks to handle authenticated pairing. Passing NULL

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2634,6 +2634,21 @@ int bt_conn_role_discovery(struct bt_conn *conn, uint8_t *role);
  */
 int bt_conn_switch_role(struct bt_conn *conn, uint8_t role);
 
+/** @brief Set supervision timeout.
+ *
+ *  Each physical link has a timer that is used for link supervision.
+ *  This timer is used to detect physical link loss caused by devices
+ *  moving out of range, or being blocked by interference, a device’s
+ *  power-down, or other similar failure cases.
+ *
+ *  @param conn  Connection object.
+ *  @param timeout Link supervision timeout, Range: 0x0001 to 0xFFFF
+ *                 Time Range: 0.625 ms to 40.9 s.
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1759,6 +1759,18 @@ struct bt_conn_cb {
 				      struct bt_conn_remote_info *remote_info);
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
 
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+	/** @brief The connection mode change
+	 *
+	 *  This callback notifies the application controller mode changed
+	 *
+	 *  @param conn Connection object.
+	 *  @param mode Active/Sniff mode.
+	 *  @param interval Sniff interval.
+	 */
+	void (*mode_changed)(struct bt_conn *conn, uint8_t mode, uint16_t interval);
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 	/** @brief The PHY of the connection has changed.
 	 *
@@ -2568,6 +2580,30 @@ struct bt_br_conn_param {
  */
 struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 				  const struct bt_br_conn_param *param);
+
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+/** @brief bluetooth conn check and enter sniff mode
+ *
+ *  This function is used to identify which ACL link connection is to
+ *  be placed in Sniff mode
+ *
+ *  @param conn bt_conn conn
+ *  @param min_interval Minimum sniff interval.
+ *  @param max_interval Maxmum sniff interval.
+ *  @param attempt Number of Baseband receive slots for sniff attempt.
+ *  @param timeout Number of Baseband receive slots for sniff timeout.
+ */
+int bt_conn_enter_sniff_mode(struct bt_conn *conn, uint16_t min_interval, uint16_t max_interval,
+			     uint16_t attempt, uint16_t timeout);
+
+/** @brief bluetooth conn check and exit sniff mode
+ *
+ *  @param conn bt_conn conn
+ *
+ *  @return  Zero for success, non-zero otherwise.
+ */
+int bt_conn_exit_sniff_mode(struct bt_conn *conn);
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -565,6 +565,19 @@ struct bt_hci_cp_exit_sniff_mode {
 	uint16_t handle;
 } __packed;
 
+#define BT_HCI_OP_ROLE_DISCOVERY                BT_OP(BT_OGF_LINK_POLICY, 0x0009) /* 0x0809 */
+struct bt_hci_cp_role_discovery {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  role;
+} __packed;
+
+#define BT_HCI_OP_SWITCH_ROLE                   BT_OP(BT_OGF_LINK_POLICY, 0x000b) /* 0x080b */
+struct bt_hci_cp_switch_role {
+	bt_addr_t bdaddr;
+	uint8_t   role;
+} __packed;
+
 #define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001) /* 0x0c01 */
 struct bt_hci_cp_set_event_mask {
 	uint8_t  events[8];

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -156,6 +156,7 @@ struct bt_hci_cmd_hdr {
 #define BT_FEAT_2EV3_PKT(feat)                  BT_FEAT_TEST(feat, 0, 5, 5)
 #define BT_FEAT_3EV3_PKT(feat)                  BT_FEAT_TEST(feat, 0, 5, 6)
 #define BT_FEAT_3SLOT_PKT(feat)                 BT_FEAT_TEST(feat, 0, 5, 7)
+#define BT_FEAT_SSP(feat)                       BT_FEAT_TEST(feat, 0, 6, 3)
 
 /* LE features */
 #define BT_LE_FEAT_BIT_ENC                      0
@@ -600,6 +601,13 @@ struct bt_hci_cp_set_event_mask {
 } __packed;
 
 #define BT_HCI_OP_RESET                         BT_OP(BT_OGF_BASEBAND, 0x0003) /* 0x0c03 */
+
+struct bt_hci_delete_stored_link_key {
+	bt_addr_t bdaddr;
+	uint8_t   delete_all;
+} __packed;
+
+#define BT_HCI_OP_DELETE_STORED_LINK_KEY        BT_OP(BT_OGF_BASEBAND, 0x0012) /* 0x0c12 */
 
 #define BT_HCI_OP_WRITE_LOCAL_NAME              BT_OP(BT_OGF_BASEBAND, 0x0013) /* 0x0c13 */
 struct bt_hci_write_local_name {

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -612,6 +612,13 @@ struct bt_hci_rp_write_conn_accept_timeout {
 #define BT_BREDR_SCAN_INQUIRY                   0x01
 #define BT_BREDR_SCAN_PAGE                      0x02
 
+#define BT_HCI_OP_WRITE_PAGE_SCAN_ACTIVITY      BT_OP(BT_OGF_BASEBAND, 0x001c) /* 0x0c1c */
+#define BT_HCI_OP_WRITE_INQUIRY_SCAN_ACTIVITY   BT_OP(BT_OGF_BASEBAND, 0x001e) /* 0x0c1e */
+struct bt_hci_cp_write_scan_activity {
+	uint16_t interval;
+	uint16_t windown;
+} __packed;
+
 #define BT_COD(major_service, major_device, minor_device)                         \
 	(((uint32_t)major_service << 13) | ((uint32_t)major_device << 8) |            \
 	 ((uint32_t)minor_device << 2))
@@ -792,9 +799,16 @@ struct bt_hci_cp_write_link_supervision_timeout {
 	uint16_t timeout;
 } __packed;
 
+#define BT_HCI_OP_WRITE_INQUIRY_SCAN_TYPE       BT_OP(BT_OGF_BASEBAND, 0x0043) /* 0x0c43 */
+
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
 struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;
+} __packed;
+
+#define BT_HCI_OP_WRITE_PAGE_SCAN_TYPE          BT_OP(BT_OGF_BASEBAND, 0x0047) /* 0x0c47 */
+struct bt_hci_cp_write_scan_type {
+	uint8_t  type;
 } __packed;
 
 #define BT_HCI_OP_WRITE_SSP_MODE                BT_OP(BT_OGF_BASEBAND, 0x0056) /* 0x0c56 */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -483,6 +483,10 @@ struct bt_hci_cp_set_conn_encrypt {
 	uint8_t  encrypt;
 } __packed;
 
+#define BT_HCI_PAGE_SCAN_REP_MODE_R0 0x00
+#define BT_HCI_PAGE_SCAN_REP_MODE_R1 0x01
+#define BT_HCI_PAGE_SCAN_REP_MODE_R2 0x02
+
 #define BT_HCI_OP_REMOTE_NAME_REQUEST           BT_OP(BT_OGF_LINK_CTRL, 0x0019) /* 0x0419 */
 struct bt_hci_cp_remote_name_request {
 	bt_addr_t bdaddr;

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -786,6 +786,12 @@ struct bt_hci_cp_host_num_completed_packets {
 	struct bt_hci_handle_count h[0];
 } __packed;
 
+#define BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT    BT_OP(BT_OGF_BASEBAND, 0x0037) /* 0x0c37 */
+struct bt_hci_cp_write_link_supervision_timeout {
+	uint16_t handle;
+	uint16_t timeout;
+} __packed;
+
 #define BT_HCI_OP_WRITE_INQUIRY_MODE            BT_OP(BT_OGF_BASEBAND, 0x0045) /* 0x0c45 */
 struct bt_hci_cp_write_inquiry_mode {
 	uint8_t  mode;

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -355,6 +355,7 @@ struct bt_hci_cmd_hdr {
 
 /* OpCode Group Fields */
 #define BT_OGF_LINK_CTRL                        0x01
+#define BT_OGF_LINK_POLICY                      0x02
 #define BT_OGF_BASEBAND                         0x03
 #define BT_OGF_INFO                             0x04
 #define BT_OGF_STATUS                           0x05
@@ -548,6 +549,20 @@ struct bt_hci_cp_user_passkey_neg_reply {
 struct bt_hci_cp_io_capability_neg_reply {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
+} __packed;
+
+#define BT_HCI_OP_SNIFF_MODE                    BT_OP(BT_OGF_LINK_POLICY, 0x0003) /* 0x0803 */
+struct bt_hci_cp_sniff_mode {
+	uint16_t handle;
+	uint16_t max_interval;
+	uint16_t min_interval;
+	uint16_t attempt;
+	uint16_t timeout;
+} __packed;
+
+#define BT_HCI_OP_EXIT_SNIFF_MODE               BT_OP(BT_OGF_LINK_POLICY, 0x0004) /* 0x0804 */
+struct bt_hci_cp_exit_sniff_mode {
+	uint16_t handle;
 } __packed;
 
 #define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001) /* 0x0c01 */
@@ -2819,6 +2834,19 @@ struct bt_hci_evt_role_change {
 struct bt_hci_evt_num_completed_packets {
 	uint8_t  num_handles;
 	struct bt_hci_handle_count h[0];
+} __packed;
+
+/* Current mode */
+#define BT_ACTIVE_MODE	0x00
+#define BT_HOLD_MODE	0x01
+#define BT_SNIFF_MODE	0x02
+
+#define BT_HCI_EVT_MODE_CHANGE                  0x14
+struct bt_hci_evt_mode_change {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  mode;
+	uint16_t interval;
 } __packed;
 
 #define BT_HCI_EVT_PIN_CODE_REQ                 0x16

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -578,6 +578,18 @@ struct bt_hci_cp_switch_role {
 	uint8_t   role;
 } __packed;
 
+#define BT_HCI_POLICY_ROLE_SWITCH BIT(0)
+#define BT_HCI_POLICY_HOLD_MODE   BIT(1)
+#define BT_HCI_POLICY_SNIFF_MODE  BIT(2)
+
+#define BT_HCI_OP_READ_LINK_POLICY_SETTINGS     BT_OP(BT_OGF_LINK_POLICY, 0x000c) /* 0x080c */
+
+#define BT_HCI_OP_WRITE_LINK_POLICY_SETTINGS    BT_OP(BT_OGF_LINK_POLICY, 0x000d) /* 0x080d */
+struct bt_hci_cp_write_link_policy_settings {
+	uint16_t handle;
+	uint16_t link_policy;
+} __packed;
+
 #define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001) /* 0x0c01 */
 struct bt_hci_cp_set_event_mask {
 	uint8_t  events[8];

--- a/port/kernel/sem.c
+++ b/port/kernel/sem.c
@@ -51,7 +51,7 @@ void k_sem_give(struct k_sem *sem)
 
 	nxsem_get_value(&sem->sem, &semcount);
 
-	if (semcount < (int)sem->limit)
+	if (semcount < 0 || (uint32_t)semcount < sem->limit)
 		nxsem_post(&sem->sem);
 }
 

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -26,6 +26,16 @@ config BT_MAX_SCO_CONN
 	  Maximum number of simultaneous Bluetooth synchronous connections
 	  supported. The minimum (and default) number is 1.
 
+config BT_CONN_REQ_AUTO_HANDLE
+	bool "Automatically handle incoming connection requests"
+	default y
+	help
+	  Automatically handle connection requests. If this option is enabled,
+	  the stack will automatically accept incoming connection requests, and
+	  the application will not be notified of the connection request. If this
+	  option is disabled, the application will be notified of incoming connection
+	  requests, and the application must accept or reject the connection.
+
 config BT_RFCOMM
 	bool "Bluetooth RFCOMM protocol support [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -221,6 +221,13 @@ config BT_COD
 	  consult the following link:
 	  https://www.bluetooth.com/specifications/assigned-numbers
 
+config BT_POWER_MODE_CONTROL
+	bool "Bluetooth Power Mode Control(Active/Sniff)"
+	help
+	  This option enables the power mode control feature. This feature
+	  allows the application to control the power mode of the Bluetooth
+	  controller.
+
 endif # BT_CLASSIC
 
 endmenu

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1104,3 +1104,92 @@ int bt_br_set_discoverable(bool enable)
 		return write_scan_enable(BT_BREDR_SCAN_PAGE);
 	}
 }
+
+static int write_scan_activity(uint16_t opcode, uint16_t interval, uint16_t windown)
+{
+	struct bt_hci_cp_write_scan_activity *cp;
+	struct net_buf *buf;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	buf = bt_hci_cmd_create(opcode, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->interval = sys_cpu_to_le16(interval);
+	cp->windown = sys_cpu_to_le16(windown);
+
+	return bt_hci_cmd_send(opcode, buf);
+}
+
+int bt_br_write_page_scan_activity(uint16_t interval, uint16_t window)
+{
+	return write_scan_activity(BT_HCI_OP_WRITE_PAGE_SCAN_ACTIVITY, interval, window);
+}
+
+int bt_br_write_inquiry_scan_activity(uint16_t interval, uint16_t window)
+{
+	return write_scan_activity(BT_HCI_OP_WRITE_INQUIRY_SCAN_ACTIVITY, interval, window);
+}
+
+static int write_scan_type(uint16_t opcode, uint8_t type)
+{
+	struct bt_hci_cp_write_scan_type *cp;
+	struct net_buf *buf;
+	int err;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	buf = bt_hci_cmd_create(opcode, 1);
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->type = type;
+
+	err = bt_hci_cmd_send_sync(opcode, buf, NULL);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}
+
+int bt_br_write_inquiry_scan_type(uint8_t type)
+{
+	return write_scan_type(BT_HCI_OP_WRITE_INQUIRY_SCAN_TYPE, type);
+}
+
+int bt_br_write_page_scan_type(uint8_t type)
+{
+	return write_scan_type(BT_HCI_OP_WRITE_PAGE_SCAN_TYPE, type);
+}
+
+int bt_br_set_class_of_device(uint32_t local_cod)
+{
+	struct net_buf *buf;
+	struct bt_hci_cp_write_class_of_device *class_cp;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_CLASS_OF_DEVICE, sizeof(*class_cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	class_cp = net_buf_add(buf, sizeof(*class_cp));
+	class_cp->class_of_device[0] = (uint8_t)local_cod;
+	class_cp->class_of_device[1] = (uint8_t)(local_cod >> 8);
+	class_cp->class_of_device[2] = (uint8_t)(local_cod >> 16);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_CLASS_OF_DEVICE, buf, NULL);
+}

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1193,3 +1193,24 @@ int bt_br_set_class_of_device(uint32_t local_cod)
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_CLASS_OF_DEVICE, buf, NULL);
 }
+
+int bt_br_write_local_name(const char *name)
+{
+	struct net_buf *buf;
+	struct bt_hci_write_local_name *name_cp;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_LOCAL_NAME, sizeof(*name_cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	name_cp = net_buf_add(buf, sizeof(*name_cp));
+	strncpy((char *)name_cp->local_name, name,
+		sizeof(name_cp->local_name));
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LOCAL_NAME, buf, NULL);
+}

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -676,6 +676,7 @@ void bt_hci_role_change(struct net_buf *buf)
 		conn->role = BT_CONN_ROLE_CENTRAL;
 	}
 
+	bt_conn_notify_role_changed(conn, conn->role);
 	bt_conn_unref(conn);
 }
 

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -241,6 +241,12 @@ void bt_hci_conn_complete(struct net_buf *buf)
 	}
 
 	if (evt->status) {
+		if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND)) {
+			atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND);
+			bt_conn_security_changed(conn, evt->status,
+						bt_security_err_get(evt->status));
+		}
+
 		conn->err = evt->status;
 		bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		bt_conn_unref(conn);
@@ -261,6 +267,17 @@ void bt_hci_conn_complete(struct net_buf *buf)
 	atomic_set_bit_to(conn->flags, BT_CONN_BR_BONDABLE, bt_get_bondable());
 
 	bt_conn_connected(conn);
+
+	if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND)) {
+		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND);
+		if (bt_conn_set_security(conn, conn->attempt_sec_level)) {
+			bt_conn_security_changed(conn, BT_HCI_ERR_AUTH_FAIL,
+						BT_SECURITY_ERR_AUTH_FAIL);
+			bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+			bt_conn_unref(conn);
+			return;
+		}
+	}
 
 	bt_conn_unref(conn);
 
@@ -1290,6 +1307,60 @@ int bt_br_remote_name_request(const bt_addr_t *bdaddr, bt_br_remote_name_req_cb_
 		/* clear control block */
 		memset(&rnr_cb, 0, sizeof(rnr_cb));
 		return err;
+	}
+
+	return 0;
+}
+
+int bt_br_delete_stored_link_key(const bt_addr_t *bdaddr, bool delete_all)
+{
+	struct net_buf *buf;
+	struct bt_hci_delete_stored_link_key *cp;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_DELETE_STORED_LINK_KEY, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	memset(cp, 0, sizeof(*cp));
+	bt_addr_copy(&cp->bdaddr, bdaddr);
+	cp->delete_all = delete_all;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_DELETE_STORED_LINK_KEY, buf, NULL);
+}
+
+int bt_br_unpair(bt_addr_t *bdaddr)
+{
+	struct bt_conn_auth_info_cb *listener, *next;
+	bt_addr_le_t addr;
+	struct bt_conn *conn;
+
+	if (!IS_ENABLED(CONFIG_BT_CLASSIC)) {
+		return -ENOTSUP;
+	}
+
+	/* Disconnect acl connection if connection is existed */
+	conn = bt_conn_lookup_addr_br(bdaddr);
+	if (conn) {
+		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+		bt_conn_unref(conn);
+	}
+
+	/* Delete stored link key from settings */
+	bt_keys_link_key_clear_addr(bdaddr);
+
+	/* Delete stored link key from controller */
+	bt_br_delete_stored_link_key(bdaddr, true);
+
+	addr.type = BT_ADDR_LE_PUBLIC;
+	memcpy(&addr, bdaddr, sizeof(addr));
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+					  next, node) {
+		if (listener->bond_deleted) {
+			listener->bond_deleted(0, &addr);
+		}
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -22,10 +22,18 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_br);
 
+struct bt_br_rnr_cb {
+	bt_addr_t addr;
+	bt_br_remote_name_req_cb_t cb;
+} __packed;
+
 struct bt_br_discovery_result *discovery_results;
 static size_t discovery_results_size;
 static size_t discovery_results_count;
 static sys_slist_t discovery_cbs = SYS_SLIST_STATIC_INIT(&discovery_cbs);
+
+/* remote name request callback */
+static struct bt_br_rnr_cb rnr_cb;
 
 static int reject_conn(const bt_addr_t *bdaddr, uint8_t reason)
 {
@@ -422,6 +430,20 @@ static struct bt_br_discovery_result *get_result_slot(const bt_addr_t *addr, int
 	return result;
 }
 
+static struct bt_br_discovery_result *find_discovery_result(const bt_addr_t *addr)
+{
+	size_t i;
+
+	/* check if already present in results */
+	for (i = 0; i < discovery_results_count; i++) {
+		if (!bt_addr_cmp(addr, &discovery_results[i].addr)) {
+			return &discovery_results[i];
+		}
+	}
+
+	return NULL;
+}
+
 void bt_hci_inquiry_result_with_rssi(struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
@@ -511,6 +533,12 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 	uint8_t *eir;
 	int i;
 	struct bt_br_discovery_cb *listener, *next;
+
+	if (rnr_cb.cb && !bt_addr_cmp(&evt->bdaddr, &rnr_cb.addr)) {
+		LOG_DBG("status 0x%02x", evt->status);
+		rnr_cb.cb(&evt->bdaddr, evt->name, evt->status);
+		memset(&rnr_cb, 0, sizeof(rnr_cb));
+	}
 
 	result = get_result_slot(&evt->bdaddr, 0xff);
 	if (!result) {
@@ -1213,4 +1241,46 @@ int bt_br_write_local_name(const char *name)
 		sizeof(name_cp->local_name));
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_LOCAL_NAME, buf, NULL);
+}
+
+int bt_br_remote_name_request(const bt_addr_t *bdaddr, bt_br_remote_name_req_cb_t cb)
+{
+	struct bt_br_discovery_result *result;
+	struct bt_br_discovery_priv *priv;
+	int err;
+
+	if (rnr_cb.cb) {
+		return -EBUSY;
+	}
+
+	/* save remote name request control block */
+	rnr_cb.cb = cb;
+	bt_addr_copy(&rnr_cb.addr, bdaddr);
+
+	/* check if we have a cached result */
+	result = find_discovery_result(bdaddr);
+	if (result) {
+		/* check is resolving, just return if resolving */
+		priv = (struct bt_br_discovery_priv *)&result->_priv;
+		if (priv->resolving) {
+			return 0;
+		}
+
+		priv->resolving = 1;
+		err = request_name(bdaddr, priv->pscan_rep_mode, priv->clock_offset);
+	} else {
+		/* start discovery to resolve name by default param */
+		err = request_name(bdaddr, BT_HCI_PAGE_SCAN_REP_MODE_R2, 0);
+	}
+
+	if (err) {
+		LOG_ERR("Unable to request name for %s (err %d)", bt_addr_str(bdaddr), err);
+		rnr_cb.cb(bdaddr, NULL, BT_HCI_ERR_UNSPECIFIED);
+
+		/* clear control block */
+		memset(&rnr_cb, 0, sizeof(rnr_cb));
+		return err;
+	}
+
+	return 0;
 }

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -679,6 +679,34 @@ void bt_hci_role_change(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+void bt_hci_link_mode_change(struct net_buf *buf)
+{
+	struct bt_hci_evt_mode_change *evt = (void *)buf->data;
+	uint16_t handle = sys_le16_to_cpu(evt->handle);
+	uint16_t interval = sys_le16_to_cpu(evt->interval);
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_handle(handle, BT_CONN_TYPE_BR);
+	if (!conn) {
+		LOG_ERR("Can't find conn for handle 0x%x", handle);
+		return;
+	}
+
+	if (evt->status || (conn->type != BT_CONN_TYPE_BR)) {
+		LOG_ERR("Error %d, type %d", evt->status, conn->type);
+	} else {
+		LOG_DBG("hdl 0x%x mode %d intervel %d", handle, evt->mode, interval);
+		if (evt->mode == BT_ACTIVE_MODE || evt->mode == BT_SNIFF_MODE) {
+			conn->br.mode = evt->mode;
+			bt_conn_notify_mode_changed(conn, evt->mode, interval);
+		}
+	}
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
 static int read_ext_features(void)
 {
 	int i;

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -243,6 +243,18 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 	}
 }
 
+static void ssp_link_key_notify(struct bt_conn *conn, uint8_t *key, uint8_t key_type)
+{
+	struct bt_conn_auth_info_cb *listener, *next;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
+						next, node) {
+		if (listener->link_key_notify) {
+			listener->link_key_notify(conn, key, key_type);
+		}
+	}
+}
+
 static void ssp_auth(struct bt_conn *conn, uint32_t passkey)
 {
 	conn->br.pairing_method = ssp_pair_method(conn);
@@ -458,6 +470,7 @@ void bt_hci_link_key_notify(struct net_buf *buf)
 
 	/* clear any old Link Key flags */
 	conn->br.link_key->flags = 0U;
+	conn->br.link_key->key_type = evt->key_type;
 
 	switch (evt->key_type) {
 	case BT_LK_COMBINATION:
@@ -492,9 +505,11 @@ void bt_hci_link_key_notify(struct net_buf *buf)
 		break;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
-	    !atomic_test_bit(conn->flags, BT_CONN_BR_NOBOND)) {
-		bt_keys_link_key_store(conn->br.link_key);
+	if (!atomic_test_bit(conn->flags, BT_CONN_BR_NOBOND)) {
+		ssp_link_key_notify(conn, conn->br.link_key->val, evt->key_type);
+		if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+			bt_keys_link_key_store(conn->br.link_key);
+		}
 	}
 
 	bt_conn_unref(conn);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -4246,6 +4246,7 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
 
+#if defined(CONFIG_BT_CLASSIC)
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 int bt_conn_enter_sniff_mode(struct bt_conn *conn, uint16_t min_interval, uint16_t max_interval,
 			     uint16_t attempt, uint16_t timeout)
@@ -4323,8 +4324,81 @@ void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t in
 		}
 	}
 }
-
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
+int bt_conn_role_discovery(struct bt_conn *conn, uint8_t *role)
+{
+	int err;
+	struct bt_hci_cp_role_discovery *rp;
+	struct net_buf *buf;
+	struct net_buf *rsp;
+
+	if (conn->type != BT_CONN_TYPE_BR || conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_ROLE_DISCOVERY, sizeof(uint16_t));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	net_buf_add_le16(buf, conn->handle);
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_ROLE_DISCOVERY, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *)rsp->data;
+	*role = rp->role;
+	net_buf_unref(rsp);
+
+	return 0;
+}
+
+int bt_conn_switch_role(struct bt_conn *conn, uint8_t role)
+{
+	struct bt_hci_cp_switch_role *cp;
+	struct net_buf *buf;
+
+	if (role != BT_HCI_ROLE_CENTRAL && role != BT_HCI_ROLE_PERIPHERAL) {
+		return -EINVAL;
+	}
+
+	if (conn->role == role) {
+		return -EBUSY;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SWITCH_ROLE, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+
+	memset(cp, 0, sizeof(*cp));
+	memcpy(&cp->bdaddr, &conn->br.dst, sizeof(cp->bdaddr));
+	cp->role = role;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_SWITCH_ROLE, buf, NULL);
+}
+
+void bt_conn_notify_role_changed(struct bt_conn *conn, uint8_t role)
+{
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+		if (callback->role_changed) {
+			callback->role_changed(conn, role);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
+		if (cb->role_changed) {
+			cb->role_changed(conn, role);
+		}
+	}
+}
+#endif /* CONFIG_BT_CLASSIC */
 #endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_CONN_TX_NOTIFY_WQ)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2780,6 +2780,64 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP */
 
+#if defined(CONFIG_BT_CLASSIC)
+struct bt_conn *bt_conn_pair_br(bt_addr_t *bdaddr, bt_security_t security)
+{
+	struct bt_conn *conn;
+	int err;
+
+	LOG_DBG("");
+
+	/* Tell controller to delete the link key if it has one stored */
+	err = bt_br_delete_stored_link_key(bdaddr, 1);
+	if (err) {
+		return NULL;
+	}
+
+	if (!BT_FEAT_SSP(bt_dev.features)) {
+		/* pin type */
+		LOG_DBG("pin type");
+	}
+
+	/* Check if connection is existed */
+	conn = bt_conn_lookup_addr_br(bdaddr);
+	if (conn) {
+		/* Check pairing process is onging */
+		if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_INITIATOR) ||
+			atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND) ||
+			atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING)) {
+			bt_conn_unref(conn);
+			return NULL;
+		}
+
+		if (conn->state == BT_CONN_CONNECTED) {
+			err = bt_conn_set_security(conn, security);
+			if (!err) {
+				return conn;
+			}
+		} else if (conn->state == BT_CONN_INITIATING) {
+			conn->attempt_sec_level = security;
+			atomic_set_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND);
+			return conn;
+		}
+
+		bt_conn_unref(conn);
+		return NULL;
+	} else {
+		/* Try to create a br connection */
+		conn = bt_conn_create_br(bdaddr, BT_BR_CONN_PARAM_DEFAULT);
+		if (!conn) {
+			return NULL;
+		}
+
+		conn->attempt_sec_level = security;
+		atomic_set_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND);
+	}
+
+	return conn;
+}
+#endif /* CONFIG_BT_CLASSIC */
+
 int bt_conn_cb_register(struct bt_conn_cb *cb)
 {
 	if (sys_slist_find(&conn_cbs, &cb->_node, NULL)) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -4398,6 +4398,23 @@ void bt_conn_notify_role_changed(struct bt_conn *conn, uint8_t role)
 		}
 	}
 }
+
+int bt_conn_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout)
+{
+	struct bt_hci_cp_write_link_supervision_timeout *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	net_buf_add_le16(buf, conn->handle);
+	net_buf_add_le16(buf, timeout);
+
+	return bt_hci_cmd_send(BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT, buf);
+}
+
 #endif /* CONFIG_BT_CLASSIC */
 #endif /* CONFIG_BT_CONN */
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2915,6 +2915,7 @@ static enum bt_conn_state conn_internal_to_public_state(bt_conn_state_t state)
 
 int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 {
+	info->handle = conn->handle;
 	info->type = conn->type;
 	info->role = conn->role;
 	info->id = conn->id;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2462,6 +2462,10 @@ struct bt_conn *bt_conn_add_br(const bt_addr_t *peer)
 	conn->get_and_clear_cb = acl_get_and_clear_cb;
 	conn->has_data = acl_has_data;
 
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+	conn->br.mode = BT_ACTIVE_MODE;
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
 	return conn;
 }
 
@@ -4242,6 +4246,85 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
 
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+int bt_conn_enter_sniff_mode(struct bt_conn *conn, uint16_t min_interval, uint16_t max_interval,
+			     uint16_t attempt, uint16_t timeout)
+{
+	struct bt_hci_cp_sniff_mode *cp;
+	struct net_buf *buf;
+
+	if (conn->type != BT_CONN_TYPE_BR || conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (conn->br.mode == BT_SNIFF_MODE) {
+		return -EBUSY;
+	}
+
+	/* Check if the parameters are valid */
+	if (min_interval < 0x0006 || min_interval > 0x0540 || max_interval < 0x0006 ||
+	    max_interval > 0x0540 || min_interval > max_interval || attempt == 0 ||
+	    attempt > 0x01F3 || timeout > 0x0028) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_SNIFF_MODE, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->max_interval = sys_cpu_to_le16(max_interval);
+	cp->min_interval = sys_cpu_to_le16(min_interval);
+	cp->attempt = sys_cpu_to_le16(attempt);
+	cp->timeout = sys_cpu_to_le16(timeout);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_SNIFF_MODE, buf, NULL);
+}
+
+int bt_conn_exit_sniff_mode(struct bt_conn *conn)
+{
+	struct bt_hci_cp_exit_sniff_mode *cp;
+	struct net_buf *buf;
+
+	if (conn->type != BT_CONN_TYPE_BR || conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	if (conn->br.mode == BT_ACTIVE_MODE) {
+		return -EBUSY;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_EXIT_SNIFF_MODE, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_EXIT_SNIFF_MODE, buf, NULL);
+}
+
+void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t interval)
+{
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+		if (callback->mode_changed) {
+			callback->mode_changed(conn, mode, interval);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
+		if (cb->mode_changed) {
+			cb->mode_changed(conn, mode, interval);
+		}
+	}
+}
+
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 #endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_CONN_TX_NOTIFY_WQ)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -4416,6 +4416,21 @@ int bt_conn_set_supervision_timeout(struct bt_conn *conn, uint16_t timeout)
 	return bt_hci_cmd_send(BT_HCI_OP_WRITE_LINK_SUPERVISION_TIMEOUT, buf);
 }
 
+int bt_conn_set_link_policy_settings(struct bt_conn* conn, uint16_t policy)
+{
+	struct bt_hci_cp_write_link_policy_settings *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_LINK_POLICY_SETTINGS, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	net_buf_add_le16(buf, conn->handle);
+	net_buf_add_le16(buf, policy);
+
+	return bt_hci_cmd_send(BT_HCI_OP_WRITE_LINK_POLICY_SETTINGS, buf);
+}
 #endif /* CONFIG_BT_CLASSIC */
 #endif /* CONFIG_BT_CONN */
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -142,6 +142,11 @@ struct bt_conn_br {
 	uint8_t			features[LMP_MAX_PAGES][8];
 
 	struct bt_keys_link_key	*link_key;
+
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+	/* For power mode */
+	uint8_t mode;
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 };
 
 struct bt_conn_sco {
@@ -531,6 +536,10 @@ void bt_conn_identity_resolved(struct bt_conn *conn);
 void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 			      enum bt_security_err err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
+
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t interval);
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 
 /* Prepare a PDU to be sent over a connection */
 #if defined(CONFIG_NET_BUF_LOG)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -419,6 +419,12 @@ struct bt_conn *bt_conn_add_br(const bt_addr_t *peer);
 /* Add a new SCO connection */
 struct bt_conn *bt_conn_add_sco(const bt_addr_t *peer, int link_type);
 
+/* Accept incoming ACL connection */
+int bt_accept_conn(const bt_addr_t *bdaddr);
+
+/* Reject incoming ACL connection */
+int bt_reject_conn(const bt_addr_t *bdaddr, uint8_t reason);
+
 /* Cleanup SCO ACL reference */
 void bt_sco_cleanup_acl(struct bt_conn *sco_conn);
 
@@ -543,6 +549,7 @@ void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t in
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
 
 void bt_conn_notify_role_changed(struct bt_conn *conn, uint8_t role);
+void bt_conn_notify_connect_req(struct bt_conn *conn, uint8_t link_type, uint8_t *cod);
 #endif /* CONFIG_BT_CLASSIC */
 
 /* Prepare a PDU to be sent over a connection */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -537,9 +537,13 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 			      enum bt_security_err err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
+#if defined(CONFIG_BT_CLASSIC)
 #if defined(CONFIG_BT_POWER_MODE_CONTROL)
 void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t interval);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
+
+void bt_conn_notify_role_changed(struct bt_conn *conn, uint8_t role);
+#endif /* CONFIG_BT_CLASSIC */
 
 /* Prepare a PDU to be sent over a connection */
 #if defined(CONFIG_NET_BUF_LOG)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -64,6 +64,7 @@ enum {
 	BT_CONN_BR_NOBOND,                    /* SSP no bond pairing tracker */
 	BT_CONN_BR_GENERAL_BONDING,           /* BR general bonding */
 	BT_CONN_BR_PAIRING_INITIATOR,         /* local host starts authentication */
+	BT_CONN_BR_PAIRING_CONN_PEND,         /* local host starts authentication waiting for connection setup */
 	BT_CONN_CLEANUP,                      /* Disconnected, pending cleanup */
 	BT_CONN_AUTO_INIT_PROCEDURES_DONE,    /* Auto-initiated procedures have run */
 	BT_CONN_PERIPHERAL_PARAM_UPDATE,      /* If periph param update timer fired */
@@ -229,6 +230,7 @@ struct bt_conn {
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 	bt_security_t		sec_level;
 	bt_security_t		required_sec_level;
+	bt_security_t		attempt_sec_level;
 	uint8_t			encrypt;
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4557,6 +4557,10 @@ int bt_set_name(const char *name)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+		return bt_br_write_local_name(name);
+	}
+
 	return 0;
 #else
 	return -ENOMEM;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2962,6 +2962,10 @@ static const struct event_handler normal_events[] = {
 		      sizeof(struct bt_hci_evt_remote_ext_features)),
 	EVENT_HANDLER(BT_HCI_EVT_ROLE_CHANGE, bt_hci_role_change,
 		      sizeof(struct bt_hci_evt_role_change)),
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+	EVENT_HANDLER(BT_HCI_EVT_MODE_CHANGE, bt_hci_link_mode_change,
+		      sizeof(struct bt_hci_evt_mode_change)),
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 	EVENT_HANDLER(BT_HCI_EVT_SYNC_CONN_COMPLETE, bt_hci_synchronous_conn_complete,
 		      sizeof(struct bt_hci_evt_sync_conn_complete)),
 #endif /* CONFIG_BT_CLASSIC */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -565,6 +565,9 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf);
 void bt_hci_read_remote_features_complete(struct net_buf *buf);
 void bt_hci_read_remote_ext_features_complete(struct net_buf *buf);
 void bt_hci_role_change(struct net_buf *buf);
+#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+void bt_hci_link_mode_change(struct net_buf *buf);
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 void bt_hci_synchronous_conn_complete(struct net_buf *buf);
 
 void bt_hci_le_df_connection_iq_report(struct net_buf *buf);

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -174,10 +174,6 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 			func(&info, user_data);
 		}
 	}
-
-	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		bt_foreach_bond_br(func, user_data);
-	}
 }
 
 void bt_keys_foreach_type(enum bt_keys_type type, void (*func)(struct bt_keys *keys, void *data),

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -213,6 +213,7 @@ struct bt_keys_link_key {
 	bt_addr_t               addr;
 	uint8_t                 storage_start[0]  __aligned(sizeof(void *));
 	uint8_t                 flags;
+	uint8_t                 key_type;
 	uint8_t                 val[16];
 #if (defined(CONFIG_BT_KEYS_OVERWRITE_OLDEST))
 	uint32_t                aging_counter;
@@ -226,8 +227,6 @@ struct bt_keys_link_key *bt_keys_find_link_key(const bt_addr_t *addr);
 void bt_keys_link_key_clear(struct bt_keys_link_key *link_key);
 void bt_keys_link_key_clear_addr(const bt_addr_t *addr);
 void bt_keys_link_key_store(struct bt_keys_link_key *link_key);
-void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user_data),
-			void *user_data);
 
 /* This function is used to signal that the key has been used for paring */
 /* It updates the aging counter and saves it to flash if configuration option */

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -247,6 +247,10 @@ static int commit_settings(void)
 #if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
 	if (bt_dev.name[0] == '\0') {
 		bt_set_name(CONFIG_BT_DEVICE_NAME);
+	} else {
+		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+			bt_br_write_local_name(bt_dev.name);
+		}
 	}
 #endif
 	if (!bt_dev.id_count) {


### PR DESCRIPTION

## Summary

*Enhance Zephyr bluetooth GAP

1. add power mode control
2. add link role control
3. link supervision timeout
4. page and inquiry
5. improve set name
6. connection  handle query
7. link policy settings
8. remote name request
9. classic bond info
10. pair

.*

## Impact

*GAP.*

## Testing

*CI.*

