### PR TITLE
Bluetooth: Classic: GAP: Write EIR support

### DIFF
--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -273,6 +273,30 @@ int bt_br_set_class_of_device(uint32_t local_cod);
  */
 int bt_br_write_local_name(const char *name);
 
+/**
+ * @brief Read the Extended Inquiry Response configuration parameter of the
+ *        local BR/EDR Controller.
+ *
+ * @param status Status of the command.
+ * @param fec_required FEC required for EIR.
+ * @param eir Extended Inquiry Response data.
+ *
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error.
+ */
+int bt_br_read_ext_inq_response(uint8_t *status, uint8_t *fec_required, uint8_t *eir);
+
+/**
+ * @brief Write the Extended Inquiry Response configuration parameter of the
+ *        local BR/EDR Controller.
+ *
+ * @param fec_required FEC required for EIR.
+ *
+ * @return Zero on success or error code otherwise, positive in case
+ * of protocol error or negative (POSIX) in case of stack internal error.
+ */
+int bt_br_write_ext_inq_response(uint8_t fec_required);
+
 /** Information about a br/edr bond with a remote device. */
 struct bt_bond_info_br {
 	bt_addr_t addr;

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -156,6 +156,7 @@ struct bt_hci_cmd_hdr {
 #define BT_FEAT_2EV3_PKT(feat)                  BT_FEAT_TEST(feat, 0, 5, 5)
 #define BT_FEAT_3EV3_PKT(feat)                  BT_FEAT_TEST(feat, 0, 5, 6)
 #define BT_FEAT_3SLOT_PKT(feat)                 BT_FEAT_TEST(feat, 0, 5, 7)
+#define BT_FEAT_EIR(feat)                       BT_FEAT_TEST(feat, 0, 6, 0)
 #define BT_FEAT_SSP(feat)                       BT_FEAT_TEST(feat, 0, 6, 3)
 
 /* LE features */
@@ -720,6 +721,19 @@ struct bt_hci_rp_read_tx_power_level {
 	uint8_t  status;
 	uint16_t handle;
 	int8_t   tx_power_level;
+} __packed;
+
+#define BT_HCI_OP_READ_EXTENDED_INQUIRY_RESPONSE BT_OP(BT_OGF_BASEBAND, 0x0051) /* 0x0c51 */
+struct bt_hci_rp_read_extended_inquiry_response {
+	uint8_t  status;
+	uint8_t  fec_required;
+	uint8_t  extended_inquiry_response[240];
+} __packed;
+
+#define BT_HCI_OP_WRITE_EXTENDED_INQUIRY_RESPONSE BT_OP(BT_OGF_BASEBAND, 0x0052) /* 0x0c52 */
+struct bt_hci_cp_write_extended_inquiry_response {
+	uint8_t fec;
+	uint8_t extended_inquiry_response[240];
 } __packed;
 
 #define BT_HCI_LE_TX_POWER_PHY_1M               0x01

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4558,7 +4558,13 @@ int bt_set_name(const char *name)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		return bt_br_write_local_name(name);
+		err = bt_br_write_local_name(name);
+		if (err) {
+			LOG_WRN("Unable to set BR/EDR name");
+			return err;
+		}
+
+		return bt_br_write_ext_inq_response(true);
 	}
 
 	return 0;

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -250,6 +250,7 @@ static int commit_settings(void)
 	} else {
 		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 			bt_br_write_local_name(bt_dev.name);
+			bt_br_write_ext_inq_response(true);
 		}
 	}
 #endif


### PR DESCRIPTION
bug: v/47556

add read and write EIR API, and write EIR only implement local name EIR.

optimize the process of set name, update the EIR with local name if EIR feature is support.

## Summary

*Classic: GAP: Write EIR support.*

## Impact

*set name.*

## Testing

*CI.*

