### PR TITLE
adapter zephyr 4.0 le(stack)

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1246,6 +1246,13 @@ int bt_conn_le_phy_update(struct bt_conn *conn,
  */
 int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason);
 
+/** @brief Read the RSSI of a connection.
+ *
+ *  @param conn Connection object.
+ *  @param rssi RSSI value.
+ */
+int bt_conn_le_read_rssi(struct bt_conn *conn, int8_t *rssi);
+
 enum {
 	/** Convenience value when no options are specified. */
 	BT_CONN_LE_OPT_NONE = 0,

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3645,6 +3645,11 @@ int bt_conn_le_phy_update(struct bt_conn *conn,
 }
 #endif
 
+int bt_conn_le_read_rssi(struct bt_conn *conn, int8_t *rssi)
+{
+	return bt_le_read_conn_rssi(conn, rssi);
+}
+
 #if defined(CONFIG_BT_CENTRAL)
 static void bt_conn_set_param_le(struct bt_conn *conn,
 				 const struct bt_le_conn_param *param)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1151,6 +1151,34 @@ int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PHY, buf, NULL);
 }
 
+int bt_le_read_conn_rssi(struct bt_conn *conn, int8_t *rssi)
+{
+	struct net_buf *buf, *rsp = NULL;
+	struct bt_hci_cp_read_rssi *cp;
+	struct bt_hci_rp_read_rssi *rp;
+
+	int err;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_READ_RSSI, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_RSSI, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *)rsp->data;
+	*rssi = rp->rssi;
+
+	net_buf_unref(rsp);
+	return 0;
+}
+
 static struct bt_conn *find_pending_connect(uint8_t role, bt_addr_le_t *peer_addr)
 {
 	struct bt_conn *conn;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4070,7 +4070,7 @@ static int hci_init(void)
 		}
 	} else if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 		LOG_ERR("Non-BR/EDR controller detected");
-		return -EIO;
+		/* return -EIO; */
 	}
 #if defined(CONFIG_BT_CONN)
 	else if (!bt_dev.le.acl_mtu) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -471,6 +471,8 @@ int bt_le_set_data_len(struct bt_conn *conn, uint16_t tx_octets, uint16_t tx_tim
 int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
 		  uint8_t pref_tx_phy, uint8_t pref_rx_phy, uint8_t phy_opts);
 uint8_t bt_get_phy(uint8_t hci_phy);
+int bt_le_read_conn_rssi(struct bt_conn *conn, int8_t *rssi);
+
 /**
  * @brief Convert CTE type value from HCI format to @ref bt_df_cte_type format.
  *


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

adapter zephyr 4.0 le

## Impact

gatt/smp/gap etc

## Testing

local test gatt/smp/gap pass

