### PR TITLE
Bluetooth: GAP: SMP: check sc feature before pairing request

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -145,6 +145,7 @@ struct bt_hci_cmd_hdr {
 #define BT_FEAT_LE(feat)                        BT_FEAT_TEST(feat, 0, 4, 6)
 #define BT_FEAT_EXT_FEATURES(feat)              BT_FEAT_TEST(feat, 0, 7, 7)
 #define BT_FEAT_HOST_SSP(feat)                  BT_FEAT_TEST(feat, 1, 0, 0)
+#define BT_FEAT_HOST_SC(feat)                   BT_FEAT_TEST(feat, 1, 0, 3)
 #define BT_FEAT_SC(feat)                        BT_FEAT_TEST(feat, 2, 1, 0)
 
 #define BT_FEAT_LMP_SCO_CAPABLE(feat)           BT_FEAT_TEST(feat, 0, 1, 3)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2235,7 +2235,9 @@ static void hci_encrypt_change(struct net_buf *buf)
 			 * central on the link
 			 */
 			if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRED) &&
-			    conn->role == BT_CONN_ROLE_CENTRAL) {
+			    conn->role == BT_CONN_ROLE_CENTRAL &&
+			    BT_FEAT_HOST_SC(conn->br.features) &&
+			    BT_FEAT_SC(bt_dev.features)) {
 				bt_smp_br_send_pairing_req(conn);
 			}
 		}


### PR DESCRIPTION
bug: v/54624

Secure authentication shall be performed when both devices support the Secure Connections (Controller Support) and Secure Connections (Host Support)
features.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*check sc feature before pairing request.*

## Impact

*createbond.*

## Testing

*CI.*

