### PR TITLE
bluetooth:adapter: Modify the reason for ACL disconnection.

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -999,6 +999,8 @@ static void hci_disconn_complete(struct net_buf *buf)
 		return;
 	}
 
+	conn->err = evt->reason;
+
 	bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 
 	if (conn->type != BT_CONN_TYPE_LE) {


### PR DESCRIPTION
bug: v/55714

rootcause: When the ACL connection is disconnected, the reason for the disconnection is not assigned to the err of the conn, which results in the reason reported to the framework not being the actual reason for the ACL disconnection.