### PR TITLE
Fix h4 driver stackoverflow

### DIFF
--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -53,7 +53,7 @@ struct h4_data {
 
 #define HCI_DEBUG 0
 
-static K_KERNEL_STACK_DEFINE(rx_thread_stack, 2048);
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, 3072);
 static struct k_thread rx_thread_data;
 
 static void h4_data_dump(const char *tag, uint8_t type, uint8_t *data, uint32_t len)


### PR DESCRIPTION
bug: v/55030

25    11 111 FIFO     pthread   - Waiting  Signal    0000000000000000  0001964 0001912  97.3%! BT Driver 0x818aad 0x40708a50

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Fix h4 driver stackoverflow.*

## Impact

*N/A.*

## Testing

*CI.*

