### PR TITLE
bluetooth: adapter: Solve the problem of scanmode setting failure.

### DIFF
--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -197,6 +197,19 @@ int bt_br_set_discoverable(bool enable);
 int bt_br_set_connectable(bool enable);
 
 /**
+ * @brief Enable/disable set controller in connectable and discoverable state.
+ * 
+ * Allows make local controller to be connectable or/and discoverable.
+ * 
+ * @param disc_mode Value allowing/disallowing controller to be discoverable.
+ * @param conn_mode Value allowing/disallowing controller to be connectable.
+ * 
+ * @return Negative if fail set to requested state or requested state has been
+ *         already set. Zero if done successfully. 
+ */
+int bt_br_set_visibility(bool disc_mode, bool conn_mode);
+
+/**
  * @brief Set controller page scan activity.
  *
  * Page Scan is only performed when Page_Scan is enabled.

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1160,6 +1160,32 @@ int bt_br_set_discoverable(bool enable)
 	}
 }
 
+int bt_br_set_visibility(bool disc_mode, bool conn_mode)
+{
+	uint8_t prev = BT_BREDR_SCAN_DISABLED;
+	uint8_t next = BT_BREDR_SCAN_DISABLED;
+
+	if (disc_mode && !conn_mode)
+		return -EPERM;
+
+	if (atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN))
+		prev |= BT_BREDR_SCAN_PAGE;
+
+	if (atomic_test_bit(bt_dev.flags, BT_DEV_ISCAN))
+		prev |= BT_BREDR_SCAN_INQUIRY;
+
+	if (conn_mode)
+		next |= BT_BREDR_SCAN_PAGE;
+
+	if (disc_mode)
+		next |= BT_BREDR_SCAN_INQUIRY;
+
+	if (prev == next)
+		return -EALREADY;
+
+	return write_scan_enable(next);
+}
+
 static int write_scan_activity(uint16_t opcode, uint16_t interval, uint16_t windown)
 {
 	struct bt_hci_cp_write_scan_activity *cp;


### PR DESCRIPTION
bug: v/55642

rootcause: When the discoverable mode changes and iscan=false, bt_br_set_discoverable will not be called. Additionally, when the discoverable or connectable mode changes, it does not necessarily mean that the value of scanmode in storage will change.


