### PR TITLE
bluetooth: Modify the buffer driving RX.

### DIFF
--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -226,7 +226,7 @@ static void h4_rx_thread(void *p1, void *p2, void *p3)
 	ssize_t frame_size = 0;
 
 	while (1) {
-		static uint8_t frame[512];
+		static uint8_t frame[1026];
 		struct net_buf *buf;
 		size_t buf_tailroom;
 		size_t buf_add_len;


### PR DESCRIPTION
bug: v/58561

Rootcause: The payload length of the 3-DH5 packet is 0-1021, with the h4 driver receiving ACL Data, and a header length of 5 bytes. Therefore, the driver's receive buffer should be changed to 1026.

