### PR TITLE
Bluetooth: hci: The native.c callback parameter is incorrect, resulti…

### DIFF
--- a/port/drivers/bluetooth/hci/native.c
+++ b/port/drivers/bluetooth/hci/native.c
@@ -42,6 +42,7 @@
 
 #include "bluetooth/bluetooth.h"
 #include "drivers/bluetooth/hci_driver.h"
+#include "net_buf.h"
 
 #include <logging/log.h>
 
@@ -216,10 +217,8 @@ static const struct bt_hci_driver drv = {
 	.send		= native_send,
 };
 
-static int bt_native_init(const struct device *unused)
+static int bt_native_init(void)
 {
-	ARG_UNUSED(unused);
-
 	bt_hci_driver_register(&drv);
 
 	return 0;


### PR DESCRIPTION
…ng in a compilation error.

bug: v/58990

Change-Id: Iaca9d2370031fb3b8ac80416fb4bf45e65c7796f

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

