### PR TITLE
bluetooth: fix CONFIG_SMP conflict with nuttx.

### DIFF
--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -38,6 +38,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /* NOTE: We cannot pull in kernel.h here, need some forward declarations  */
 struct arch_esf;
 struct k_thread;

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /**
  * @defgroup isr_apis Interrupt Service Routine APIs
  * @ingroup kernel_apis

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /**
  * @brief Spinlock APIs
  * @defgroup spinlock_apis Spinlock APIs


### PR DESCRIPTION
bug: v/60613

Currently porting is not adapted to SMP.

