### PR TITLE
zblue:fix kconfig to adapt ZBLUE_SYS_CLOCK_HW_CYCLES_PER_SEC

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -799,7 +799,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 	  A value of 0 completely disables timer support in the kernel.
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
+config ZBLUE_SYS_CLOCK_HW_CYCLES_PER_SEC
 	int "System clock's h/w timer frequency"
 	help
 	  This option specifies the frequency of the hardware timer used for the


### PR DESCRIPTION


## Summary

fix kconfig to adapt ZBLUE_SYS_CLOCK_HW_CYCLES_PER_SEC

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

