### PR TITLE
BLE-related fix on PTS

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2515,6 +2515,17 @@ struct bt_conn *bt_conn_pair_br(bt_addr_t *bdaddr, bt_security_t security);
  */
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
 
+/** @brief Register LE authentication callbacks.
+ *
+ *  Register callbacks to handle authenticated pairing. Passing NULL
+ *  unregisters a previous callbacks structure.
+ *
+ *  @param cb Callback struct.
+ *
+ *  @return Zero on success or negative error code otherwise
+ */
+int bt_conn_le_auth_cb_register(const struct bt_conn_auth_cb *cb);
+
 /** @brief Overlay authentication callbacks used for a given connection.
  *
  *  This function can be used only for Bluetooth LE connections.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -104,6 +104,10 @@ const struct bt_conn_auth_cb *bt_auth;
 sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
+#if defined(CONFIG_BT_SMP)
+const struct bt_conn_auth_cb *le_auth;
+#endif /* CONFIG_BT_SMP */
+
 
 static sys_slist_t conn_cbs = SYS_SLIST_STATIC_INIT(&conn_cbs);
 
@@ -4091,6 +4095,30 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 }
 
 #if defined(CONFIG_BT_SMP)
+int bt_conn_le_auth_cb_register(const struct bt_conn_auth_cb *cb)
+{
+	if (!cb) {
+		le_auth = NULL;
+		return 0;
+	}
+
+	if (le_auth) {
+		return -EALREADY;
+	}
+
+	/* The cancel callback must always be provided if the app provides
+	 * interactive callbacks.
+	 */
+	if (!cb->cancel &&
+	    (cb->passkey_display || cb->passkey_entry || cb->passkey_confirm ||
+	     cb->pairing_confirm)) {
+		return -EINVAL;
+	}
+
+	le_auth = cb;
+	return 0;
+}
+
 int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb)
 {
 	CHECKIF(conn == NULL) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -443,6 +443,10 @@ extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
+#if defined(CONFIG_BT_SMP)
+extern const struct bt_conn_auth_cb *le_auth;
+#endif /* CONFIG_BT_SMP*/
+
 #if DT_HAS_CHOSEN(zephyr_bt_hci)
 int bt_hci_recv(const struct device *dev, struct net_buf *buf);
 #endif

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2996,6 +2996,10 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	} else {
 		rsp->oob_flag = legacy_oobd_present ? BT_SMP_OOB_PRESENT :
 				BT_SMP_OOB_NOT_PRESENT;
+#if 1 /* legacy pairing not deliver linkkey */
+		rsp->init_key_dist &= ~LINK_DIST;
+		rsp->resp_key_dist &= ~LINK_DIST;
+#endif
 	}
 
 	if ((rsp->auth_req & BT_SMP_AUTH_CT2) &&
@@ -3185,6 +3189,13 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 		req->init_key_dist = 0;
 		req->resp_key_dist = 0;
 	}
+
+#if 1 /* legacy pairing not deliver linkkey */
+	if ((req->auth_req & BT_SMP_AUTH_SC) == 0) {
+		req->init_key_dist &= ~LINK_DIST;
+		req->resp_key_dist &= ~LINK_DIST;
+	}
+#endif
 
 	smp->local_dist = req->init_key_dist;
 	smp->remote_dist = req->resp_key_dist;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -314,7 +314,7 @@ static bool le_sc_supported(void)
 static const struct bt_conn_auth_cb *latch_auth_cb(struct bt_smp *smp)
 {
 	(void)atomic_ptr_cas(&smp->auth_cb, BT_SMP_AUTH_CB_UNINITIALIZED,
-			     (atomic_ptr_val_t)bt_auth);
+			     (atomic_ptr_val_t)le_auth);
 
 	return atomic_ptr_get(&smp->auth_cb);
 }


### PR DESCRIPTION
two patchs:
bluetooth: fix legacy pairing error.
zblue: Fix for bredr and ble sharing a single auth_cb.
