### PR TITLE
bluetooth: fix build error(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) in tim…

### DIFF
--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -73,7 +73,7 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 #define sys_clock_hw_cycles_per_sec() sys_clock_hw_cycles_per_sec_runtime_get()
 #else
-#define sys_clock_hw_cycles_per_sec() CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define sys_clock_hw_cycles_per_sec() CONFIG_ZBLUE_SYS_CLOCK_HW_CYCLES_PER_SEC
 #endif
 
 /** @internal


### PR DESCRIPTION
…e_units.h.

bug: v/60642

zblue/port/include/zephyr/sys/time_units.h:76:39: error: 'CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC' undeclared (first use in this function); did you mean 'CONFIG_ZBLUE_SYS_CLOCK_HW_CYCLES_PER_SEC'? 76 | #define sys_clock_hw_cycles_per_sec() CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.


