### PR TITLE
bluetooth: Fix the issue of the second enable failure.

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4592,15 +4592,18 @@ int bt_disable_mc(uint8_t dev_id)
 #if !DT_HAS_CHOSEN(zephyr_bt_hci)
 	if (!hdev->drv) {
 		LOG_ERR("No HCI driver registered");
+		bt_dev_free(hdev);
 		return -ENODEV;
 	}
 
 	if (!hdev->drv->close) {
+		bt_dev_free(hdev);
 		return -ENOTSUP;
 	}
 #endif
 
 	if (atomic_test_and_set_bit(hdev->flags, BT_DEV_DISABLE)) {
+		bt_dev_free(hdev);
 		return -EALREADY;
 	}
 
@@ -4632,6 +4635,7 @@ int bt_disable_mc(uint8_t dev_id)
 	if (err == -ENOSYS) {
 		atomic_clear_bit(hdev->flags, BT_DEV_DISABLE);
 		atomic_set_bit(hdev->flags, BT_DEV_READY);
+		bt_dev_free(hdev);
 		return -ENOTSUP;
 	}
 #else
@@ -4642,6 +4646,7 @@ int bt_disable_mc(uint8_t dev_id)
 
 		/* Re-enable BT_DEV_READY to avoid inconsistent stack state */
 		atomic_set_bit(hdev->flags, BT_DEV_READY);
+		bt_dev_free(hdev);
 
 		return err;
 	}
@@ -4676,6 +4681,8 @@ int bt_disable_mc(uint8_t dev_id)
 	 * completed.
 	 */
 	atomic_clear_bit(hdev->flags, BT_DEV_ENABLE);
+
+	bt_dev_free(hdev);
 
 	return 0;
 }


### PR DESCRIPTION
bug:v/67024

Root cause: When bt_disable_mc is called without resetting hdev->hci, it results in hdev->hci being detected as not NULL during the next enable operation, leading to enable failure.


