### PR TITLE
Bluetooth: Clear the started flag of BT RX WQ when disabled.

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4654,6 +4654,7 @@ int bt_disable_mc(uint8_t dev_id)
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 	/* Abort RX thread */
 	k_thread_abort(&bt_workq.thread);
+	bt_workq.flags &= ~K_WORK_QUEUE_STARTED;
 #endif
 
 	/* Some functions rely on checking this bitfield */


### PR DESCRIPTION
Bluetooth: Clear the started flag of BT RX WQ when disabled.

bug: v/68660

Rootcause: Due to the K_WORK_QUEUE_STARTED flag of BT RX WQ not being cleared when disabled. When re-enabled, the BT RX WQ thread cannot be created.

