### PR TITLE
Compile: Fix warning.

### DIFF
--- a/port/kernel/poll.c
+++ b/port/kernel/poll.c
@@ -269,6 +269,7 @@ int k_poll(struct k_poll_event *events, int num_events,
 	poller.is_polling = false;
 
 	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+		events->poller = NULL;
 		k_spin_unlock(&lock, key);
 
 		return -EAGAIN;


### PR DESCRIPTION
bug: v/66237

Rootcause: Assign the address of a local variable to a pointer without timely reset
