### PR TITLE
[zblue]: Fix a2dp crash.

### DIFF
--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -44,6 +44,8 @@
 LOG_MODULE_REGISTER(bt_driver);
 
 #define DT_DRV_COMPAT zephyr_bt_hci_ttyHCI
+#define RX_THREAD_STACK_USED_MODE_SIZE    (3072)
+#define RX_THREAD_STACK_DEBUG_MODE_SIZE   (4096)
 
 struct h4_data {
 	int fd;
@@ -51,7 +53,11 @@ struct h4_data {
 	bt_hci_recv_t recv;
 	void *hci_data;
 	struct k_thread rx_thread_data;
-	K_KERNEL_STACK_DEFINE(rx_thread_stack, 3072);
+#if (CONFIG_BLUETOOTH_SERVICE_LOG_LEVEL > 2 || CONFIG_BT_DEBUG_LOG > 2)
+	K_KERNEL_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_DEBUG_MODE_SIZE);
+#else
+	K_KERNEL_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_USED_MODE_SIZE);
+#endif //(CONFIG_BLUETOOTH_SERVICE_LOG_LEVEL > 2 || CONFIG_BT_DEBUG_LOG > 2)
 	uint8_t frame[1026];
 };
 


### PR DESCRIPTION
buf: v/68534

Root cause: When performing stress testing on a2dp, the h4 driver task may crash due to insufficient stack space. in this case, the stack size needs to be modified to 4k to meet the requirements.

Change-Id: I076d8c410e50b1b221ae228b3bc18ea931f345c4

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

