### PR TITLE
Fix compile error when close SMP or classic module.

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2845,8 +2845,9 @@ void bt_l2cap_init(struct bt_dev *hdev)
 {
 	struct bt_dev_l2cap_ctx *l2cap_ctx = &l2cap_ctx_pool[hdev->dev_id];
 	hdev->l2cap_ctx = l2cap_ctx;
-
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	sys_slist_init(&l2cap_ctx->servers);
+#endif //defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	l2cap_ctx->ident = 0;
 
 	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {


### PR DESCRIPTION
bug: v/69937

Rootcause: When the CONFIG_BT_L2CAP_DYNAMIC_CHANNEL macro is disabled, calling sys_slist_init(&l2cap_ctx->servers); in the bt_l2cap_initfunction results in an error indicating that the bt_auth_info_cbs bit is not defined.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

