### PR TITLE
Fix compile error when close SMP or classic module.

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -4383,7 +4383,9 @@ int bt_conn_init(struct bt_dev *hdev)
 	conn_ctx->hdev = hdev;
 
 	k_fifo_init(&conn_ctx->free_tx);
+#if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 	sys_slist_init(&hdev->bt_auth_info_cbs);
+#endif //defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 	sys_slist_init(&conn_ctx->conn_cbs);
 	k_sem_init(&conn_ctx->pending_recycled_events, 0, K_SEM_MAX_LIMIT);
 	k_work_init(&conn_ctx->recycled_work, recycled_work_handler);


### PR DESCRIPTION
bug: v/69936

Rootcause: When the CONFIG_BT_SMP or CONFIG_BT_CLASSIC macro is disabled, calling sys_slist_init(&hdev->bt_auth_info_cbs) in the bt_conn_init function results in an error indicating that the bt_auth_info_cbs bit is not defined.

Change-Id: I9b4152b6585ef93edc0c6b7fadd553e15ecb8365

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

