### PR TITLE
Fix native.c compile error when enable native function.

### DIFF
--- a/port/Kconfig
+++ b/port/Kconfig
@@ -23,6 +23,19 @@ config BT_H4
     Bluetooth H:4 UART driver. Requires hardware flow control
     lines to be available.
 
+config BT_NATIVE
+  bool "HCI over Native"
+  default y
+  help
+    Attach local controller with direct call method.
+
+config BT_NATIVE_THREAD_STACK_SIZE
+  int "Bluetooth HCI Driver Thread Stack Size"
+  default 768
+  depends on BT_NATIVE && !BT_THREAD_NO_PREEM
+  help
+    None.
+
 config BT_MC_SHELL
   bool "Bluetooth shell"
   default n

--- a/port/drivers/bluetooth/hci/native.c
+++ b/port/drivers/bluetooth/hci/native.c
@@ -40,7 +40,7 @@
 #include <sys/ioctl.h>
 #include <sys/uio.h>
 
-#include "bluetooth/bluetooth.h"
+#include <zephyr/bluetooth/bluetooth.h>
 #include "drivers/bluetooth/hci_driver.h"
 
 #include <logging/log.h>
@@ -216,10 +216,8 @@ static const struct bt_hci_driver drv = {
 	.send		= native_send,
 };
 
-static int bt_native_init(const struct device *unused)
+static int bt_native_init(void)
 {
-	ARG_UNUSED(unused);
-
 	bt_hci_driver_register(&drv);
 
 	return 0;


### PR DESCRIPTION
VELAPLATFO-69935

Rootcause: When enabling the native feature while disabling H4, a compilation error occurs. The primary cause is incorrect parameter passing to the bt_native_init function.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

