### PR TITLE
fix Service Changed broadcast, compile warning, and enforce GAP security disconnection

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1101,6 +1101,7 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 
 no_chan:
 	l2cap_br_send_conn_rsp(conn, scid, 0, ident, result);
+	bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
 }
 
 static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3158,7 +3158,7 @@ int bt_gatt_notify_multiple(struct bt_conn *conn,
 static int gatt_indicate_mc(uint16_t handle,
 			    struct bt_gatt_indicate_params *params)
 {
-	struct notify_data data;
+	struct notify_data data = { 0 };
 	uint8_t dev_id;
 	struct bt_dev *hdev;
 
@@ -3188,7 +3188,7 @@ static int gatt_indicate_mc(uint16_t handle,
 int bt_gatt_indicate(struct bt_conn *conn,
 		     struct bt_gatt_indicate_params *params)
 {
-	struct notify_data data;
+	struct notify_data data = { 0 };
 
 	__ASSERT(params, "invalid parameters\n");
 	__ASSERT(params->attr || params->uuid, "invalid parameters\n");

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3155,6 +3155,36 @@ int bt_gatt_notify_multiple(struct bt_conn *conn,
 }
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 
+static int gatt_indicate_mc(uint16_t handle,
+			    struct bt_gatt_indicate_params *params)
+{
+	struct notify_data data;
+	uint8_t dev_id;
+	struct bt_dev *hdev;
+
+	data.err = -ENOTCONN;
+	data.type = BT_GATT_CCC_INDICATE;
+	data.ind_params = params;
+	params->_ref = 0;
+
+	for (dev_id = 0; dev_id < CONFIG_BT_NUM_CTLRS; dev_id++) {
+		hdev = bt_dev_get(dev_id);
+
+		if (!hdev) {
+			continue;
+		}
+		if (!atomic_test_bit(hdev->flags, BT_DEV_READY)) {
+			continue;
+		}
+
+		data.hdev = hdev;
+		bt_gatt_foreach_attr_type_mc(hdev->dev_id, handle, 0xffff,
+					     BT_UUID_GATT_CCC, NULL,
+					     1, notify_cb, &data);
+	}
+
+	return data.err;
+}
 int bt_gatt_indicate(struct bt_conn *conn,
 		     struct bt_gatt_indicate_params *params)
 {
@@ -3164,7 +3194,7 @@ int bt_gatt_indicate(struct bt_conn *conn,
 	__ASSERT(params->attr || params->uuid, "invalid parameters\n");
 
 	if (!conn) {
-		return -ENOTCONN;
+		return gatt_indicate_mc(bt_gatt_attr_get_handle(data.attr), params);
 	}
 
 	if (!atomic_test_bit(conn->hdev->flags, BT_DEV_READY)) {
@@ -3203,20 +3233,8 @@ int bt_gatt_indicate(struct bt_conn *conn,
 		data.handle = bt_gatt_attr_value_handle(data.attr);
 	}
 
-	if (conn) {
-		params->_ref = 1;
-		return gatt_indicate(conn, data.handle, params);
-	}
-
-	data.err = -ENOTCONN;
-	data.type = BT_GATT_CCC_INDICATE;
-	data.ind_params = params;
-
-	params->_ref = 0;
-	bt_gatt_foreach_attr_type_mc(conn->hdev->dev_id, data.handle, 0xffff, BT_UUID_GATT_CCC, NULL,
-				  1, notify_cb, &data);
-
-	return data.err;
+	params->_ref = 1;
+	return gatt_indicate(conn, data.handle, params);
 }
 
 uint16_t bt_gatt_get_mtu(struct bt_conn *conn)


### PR DESCRIPTION
📖 PR Description

This PR addresses multiple issues in the Bluetooth stack related to GATT indication broadcasting, compiler warnings, and GAP security compliance.

🔧 Fixes & Improvements

GATT Indication

Fixed bt_gatt_indicate(NULL, …) behavior for Service Changed characteristic.

Added bt_gatt_indicate_mc() to correctly handle broadcast mode.

Properly iterates over all controllers and notifies subscribed peers.

Ensures Service Changed indications are delivered to all connections when conn = NULL.

Resolved inconsistent error handling (-ENOTCONN) and removed unsafe conn->hdev access.

Build Warning

Fixed maybe-uninitialized compiler warning in bt_gatt_indicate.

GAP Security Enforcement

Enforced ACL disconnection when security requirements are not met.

Complies with Bluetooth Spec v5.4 Core, Vol 3, Part C, Sec 10.2.3.

Aligns with PTS GAP/SEC/SEM/BV-10-C test case by disconnecting with a proper security error reason.

🐞 Bugs

v/69013: Service Changed indication broadcast & compile warning.

v/70809: GAP security block disconnection compliance.