### PR TITLE
Bluetooth: L2CAP: Classic: Add unregister interface

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -537,6 +537,22 @@ static inline int bt_l2cap_br_server_register(struct bt_l2cap_server *server)
 }
 #endif
 
+/** @brief Unregister L2CAP server on BR/EDR oriented connection.
+ *
+ *  Unregister L2CAP server for a PSM.
+ *
+ *  @param server Server structure.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_l2cap_br_server_unregister_mc(uint8_t dev_id, struct bt_l2cap_server *server);
+#ifdef CONFIG_BT_ORIGINAL_API
+static inline int bt_l2cap_br_server_unregister(struct bt_l2cap_server *server)
+{
+	return bt_l2cap_br_server_unregister_mc(0, server);
+}
+#endif
+
 /** @brief Connect Enhanced Credit Based L2CAP channels
  *
  *  Connect up to 5 L2CAP channels by PSM, once the connection is completed

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1200,6 +1200,27 @@ int bt_l2cap_br_server_register_mc(uint8_t dev_id, struct bt_l2cap_server *serve
 	return 0;
 }
 
+int bt_l2cap_br_server_unregister_mc(uint8_t dev_id, struct bt_l2cap_server *server)
+{
+	struct bt_dev *hdev = bt_dev_get(dev_id);
+
+	if (!hdev) {
+		return -ENODEV;
+	}
+
+	CHECKIF(server == NULL) {
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&hdev->l2cap_br_ctx->br_servers, &server->node)) {
+		return -ENOENT;
+	}
+
+	LOG_DBG("PSM 0x%04x unregistered", server->psm);
+
+	return 0;
+}
+
 static void l2cap_br_send_reject(struct bt_conn *conn, uint8_t ident,
 				 uint16_t reason, void *data, uint8_t data_len)
 {


### PR DESCRIPTION

## Summary

Bluetooth: L2CAP: Classic: Add unregister interface

## Impact

Node

## Testing

test pass
