### PR TITLE
Bluetooth: SDP: wrap sdp attr item into u16 common func

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -2560,6 +2560,33 @@ static int sdp_get_param_item(struct bt_sdp_uuid_desc *pd_item, uint16_t *param)
 	return 0;
 }
 
+static int sdp_get_u16_data(const struct bt_sdp_attr_item *attr, uint16_t *u16)
+{
+	const uint8_t *p;
+
+	if (!u16) {
+		LOG_ERR("Invalid pointer.");
+		return -EINVAL;
+	}
+
+	/* assert 16bit can be read safely */
+	if (attr->len != (sizeof(uint8_t) + sizeof(*u16))) {
+		LOG_ERR("Invalid data length %u", attr->len);
+		return -EMSGSIZE;
+	}
+
+	p = attr->val;
+	__ASSERT(p != NULL, "attr->val cannot be NULL");
+	if (p[0] != BT_SDP_UINT16) {
+		LOG_ERR("Invalid DTD 0x%02x", p[0]);
+		return -EINVAL;
+	}
+
+	*u16 = sys_get_be16(++p);
+
+	return 0;
+}
+
 int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
 			   uint16_t *param)
 {
@@ -2639,36 +2666,13 @@ int bt_sdp_get_profile_version(const struct net_buf *buf, uint16_t profile,
 int bt_sdp_get_features(const struct net_buf *buf, uint16_t *features)
 {
 	struct bt_sdp_attr_item attr;
-	const uint8_t *p;
-	int res;
+	int err;
 
-	res = bt_sdp_get_attr(buf, &attr, BT_SDP_ATTR_SUPPORTED_FEATURES);
-	if (res < 0) {
-		LOG_WRN("Attribute 0x%04x not found, err %d", BT_SDP_ATTR_SUPPORTED_FEATURES, res);
-		return res;
+	err = bt_sdp_get_attr(buf, &attr, BT_SDP_ATTR_SUPPORTED_FEATURES);
+	if (err < 0) {
+		LOG_WRN("Attribute 0x%04x not found, err %d", BT_SDP_ATTR_SUPPORTED_FEATURES, err);
+		return err;
 	}
 
-	p = attr.val;
-	BT_ASSERT(p);
-
-	if (p[0] != BT_SDP_UINT16) {
-		LOG_ERR("Invalid DTD 0x%02x", p[0]);
-		return -EINVAL;
-	}
-
-	/* assert 16bit can be read safely */
-	if (attr.len < 3) {
-		LOG_ERR("Data length too short %u", attr.len);
-		return -EMSGSIZE;
-	}
-
-	*features = sys_get_be16(++p);
-	p += sizeof(uint16_t);
-
-	if (p - attr.val != attr.len) {
-		LOG_ERR("Invalid data length %u", attr.len);
-		return -EMSGSIZE;
-	}
-
-	return 0;
+	return sdp_get_u16_data(&attr, features);
 }


### PR DESCRIPTION
Wrap sdp attr item into u16 common function, and it would help to add pnp etc info

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Bluetooth: SDP: wrap sdp attr item into u16 common func

## Impact

SDP find

## Testing

local test pass

