### PR TITLE
Fix disable sequence, driver adaptation, and bond/link key handling

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -514,19 +514,7 @@ static int bt_nxp_close(const struct device *dev)
 {
 	struct bt_nxp_data *hci = dev->data;
 	int ret = 0;
-	/* Reset the Controller */
-	if (IS_ENABLED(CONFIG_BT_HCI_HOST)) {
-		ret = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
-		if (ret) {
-			LOG_ERR("Failed to reset BLE controller");
-		}
-		k_sleep(K_SECONDS(1));
 
-		ret = PLATFORM_TerminateBle();
-		if (ret < 0) {
-			LOG_ERR("Failed to shutdown BLE controller");
-		}
-	}
 	hci->recv = NULL;
 
 	return ret;

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -347,14 +348,6 @@ static int bt_ipc_close(const struct device *dev)
 {
 	struct ipc_data *ipc = dev->data;
 	int err;
-
-	if (IS_ENABLED(CONFIG_BT_HCI_HOST)) {
-		err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
-		if (err) {
-			LOG_ERR("Sending reset command failed with: %d", err);
-			return err;
-		}
-	}
 
 	err = ipc_service_deregister_endpoint(&ipc->hci_ept);
 	if (err) {

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -38,6 +38,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /* NOTE: We cannot pull in kernel.h here, need some forward declarations  */
 struct arch_esf;
 struct k_thread;

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /**
  * @defgroup isr_apis Interrupt Service Routine APIs
  * @ingroup kernel_apis

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#undef CONFIG_SMP
+
 /**
  * @brief Spinlock APIs
  * @defgroup spinlock_apis Spinlock APIs

--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -376,7 +376,7 @@ static int h4_open(const struct device *dev, bt_hci_recv_t recv, void *hci_data)
 		return -EINVAL;
 	}
 
-	ret = snprintf(dev_name, sizeof(dev_name), "/dev/%s", dev->name);
+	ret = snprintf(dev_name, sizeof(dev_name), "%s", dev->name);
 	if (ret < 0 || ret >= sizeof(dev_name)) {
 		LOG_ERR("dev_name:%s snprintf failed, ret %d, ", dev->name, ret);
 		return -EINVAL;

--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -421,8 +421,23 @@ bail:
 	return ret;
 }
 
+static int h4_close(const struct device *dev)
+{
+	struct h4_data *h4 = dev->data;
+
+	LOG_DBG("close h4");
+
+	k_thread_abort(&rx_thread_data);
+
+	close(h4->fd);
+	h4->fd = -1;
+
+	return 0;
+}
+
 static const struct bt_hci_driver_api h4_drv_api = {
 	.open = h4_open,
+	.close = h4_close,
 	.send = h4_send,
 };
 

--- a/port/drivers/bluetooth/hci/h4.c
+++ b/port/drivers/bluetooth/hci/h4.c
@@ -427,7 +427,7 @@ static int h4_close(const struct device *dev)
 
 	LOG_DBG("close h4");
 
-	k_thread_abort(&rx_thread_data);
+	k_thread_abort(&h4->rx_thread_data);
 
 	close(h4->fd);
 	h4->fd = -1;

--- a/port/include/zephyr/devicetree_generated.h
+++ b/port/include/zephyr/devicetree_generated.h
@@ -21,10 +21,10 @@ extern struct device __device_dts_ord_DT_N_INST_0_zephyr_bt_hci_ttyHCI0_ORD;
 #define DT_CHOSEN_zephyr_bt_hci_EXISTS  1
 #define DT_CHOSEN_zephyr_bt_hci0   DT_N_INST_0_zephyr_bt_hci_ttyHCI0
 
-#define DT_N_INST_0_zephyr_bt_hci_ttyHCI0_FULL_NAME "ttyHCI0"
+#define DT_N_INST_0_zephyr_bt_hci_ttyHCI0_FULL_NAME CONFIG_BT_UART_ON_DEV_NAME
 
 extern struct device __device_dts_ord_DT_N_INST_1_zephyr_bt_hci_ttyHCI1_ORD;
 
 #define DT_CHOSEN_zephyr_bt_hci1   DT_N_INST_1_zephyr_bt_hci_ttyHCI1
 
-#define DT_N_INST_1_zephyr_bt_hci_ttyHCI1_FULL_NAME "ttyHCI1"
+#define DT_N_INST_1_zephyr_bt_hci_ttyHCI1_FULL_NAME "/dev/ttyHCI1"

--- a/port/kernel/thread.c
+++ b/port/kernel/thread.c
@@ -144,4 +144,12 @@ void k_thread_resume(k_tid_t thread)
 
 void k_thread_abort(k_tid_t thread)
 {
+	pthread_t pid = (pthread_t)thread->init_data;
+
+	if (sys_dnode_is_linked(&thread->base.qnode_dlist)) {
+		sys_dlist_remove(&thread->base.qnode_dlist);
+	}
+
+	pthread_cancel(pid);
+	pthread_detach(pid);
 }

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2663,6 +2663,37 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],
 #endif /* CONFIG_BT_SMP */
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
+uint8_t bt_conn_read_enc_key_size(const struct bt_conn *conn)
+{
+	struct bt_hci_cp_read_encryption_key_size *cp;
+	struct bt_hci_rp_read_encryption_key_size *rp;
+	struct net_buf *buf;
+	struct net_buf *rsp;
+	uint8_t key_size;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE,
+				sizeof(*cp));
+	if (!buf) {
+		return 0;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+
+	if (bt_hci_cmd_send_sync(conn->hdev, BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE,
+				buf, &rsp)) {
+		return 0;
+	}
+
+	rp = (void *)rsp->data;
+
+	key_size = rp->status ? 0 : rp->key_size;
+
+	net_buf_unref(rsp);
+
+	return key_size;
+}
+
 uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 {
 	if (!conn->encrypt) {
@@ -2671,33 +2702,7 @@ uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 
 	if (IS_ENABLED(CONFIG_BT_CLASSIC) &&
 	    conn->type == BT_CONN_TYPE_BR) {
-		struct bt_hci_cp_read_encryption_key_size *cp;
-		struct bt_hci_rp_read_encryption_key_size *rp;
-		struct net_buf *buf;
-		struct net_buf *rsp;
-		uint8_t key_size;
-
-		buf = bt_hci_cmd_create(BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE,
-					sizeof(*cp));
-		if (!buf) {
-			return 0;
-		}
-
-		cp = net_buf_add(buf, sizeof(*cp));
-		cp->handle = sys_cpu_to_le16(conn->handle);
-
-		if (bt_hci_cmd_send_sync(conn->hdev, BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE,
-					buf, &rsp)) {
-			return 0;
-		}
-
-		rp = (void *)rsp->data;
-
-		key_size = rp->status ? 0 : rp->key_size;
-
-		net_buf_unref(rsp);
-
-		return key_size;
+			return conn->br.link_key ? conn->br.link_key->key_size : 0;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2017-2021 Nordic Semiconductor ASA
  * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -2506,16 +2507,9 @@ static void le_ltk_request(struct bt_dev *hdev, struct net_buf *buf)
 }
 #endif /* CONFIG_BT_SMP */
 
-static void hci_reset_complete(struct bt_dev *hdev, struct net_buf *buf)
+static void hci_reset_complete(struct bt_dev *hdev)
 {
-	uint8_t status = buf->data[0];
 	atomic_t flags;
-
-	LOG_DBG("status 0x%02x %s", status, bt_hci_err_to_str(status));
-
-	if (status) {
-		return;
-	}
 
 	if (IS_ENABLED(CONFIG_BT_OBSERVER)) {
 		bt_scan_reset(hdev);
@@ -3398,12 +3392,11 @@ static int common_init(struct bt_dev *hdev)
 	if (!drv_quirk_no_reset(hdev)) {
 		/* Send HCI_RESET */
 		syslog(LOG_INFO, "dev:%d: Sending HCI_RESET", hdev->dev_id);
-		err = bt_hci_cmd_send_sync(hdev, BT_HCI_OP_RESET, NULL, &rsp);
+		err = bt_hci_cmd_send_sync(hdev, BT_HCI_OP_RESET, NULL, NULL);
 		if (err) {
 			return err;
 		}
-		hci_reset_complete(hdev, rsp);
-		net_buf_unref(rsp);
+		hci_reset_complete(hdev);
 	}
 
 	/* Read Local Supported Features */
@@ -4636,6 +4629,18 @@ int bt_disable_mc(uint8_t dev_id)
 	bt_conn_cleanup_all(hdev);
 	disconnected_handles_reset(hdev);
 #endif /* CONFIG_BT_CONN */
+
+	/* Reset the Controller */
+	if (!drv_quirk_no_reset(hdev)) {
+
+		err = bt_hci_cmd_send_sync(hdev, BT_HCI_OP_RESET, NULL, NULL);
+		if (err) {
+			LOG_ERR("Failed to reset BLE controller");
+			return err;
+		}
+
+		hci_reset_complete(hdev);
+	}
 
 #if DT_HAS_CHOSEN(zephyr_bt_hci)
 	err = bt_hci_close(hdev->hci);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1078,6 +1078,9 @@ static void hci_disconn_complete(struct bt_dev *hdev, struct net_buf *buf)
 		    atomic_test_and_clear_bit(conn->flags, BT_CONN_BR_NOBOND)) {
 			bt_keys_link_key_clear(hdev, conn->br.link_key);
 		}
+
+		if (conn->type == BT_CONN_TYPE_BR && conn->br.link_key != NULL)
+			conn->br.link_key->key_size = 0;
 #endif
 		bt_conn_unref(conn);
 		return;
@@ -2320,6 +2323,10 @@ static void hci_encrypt_change(struct bt_dev *hdev, struct net_buf *buf)
 			    BT_FEAT_SC(hdev->features)) {
 				bt_smp_br_send_pairing_req(conn);
 			}
+		}
+
+		if (conn->encrypt) {
+			conn->br.link_key->key_size = bt_conn_read_enc_key_size(conn);
 		}
 	}
 #endif /* CONFIG_BT_CLASSIC */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1074,7 +1074,7 @@ static void hci_disconn_complete(struct bt_dev *hdev, struct net_buf *buf)
 		 * If only for one connection session bond was set, clear keys
 		 * database row for this connection.
 		 */
-		if (conn->type == BT_CONN_TYPE_BR &&
+		if (conn->type == BT_CONN_TYPE_BR && conn->br.link_key != NULL &&
 		    atomic_test_and_clear_bit(conn->flags, BT_CONN_BR_NOBOND)) {
 			bt_keys_link_key_clear(hdev, conn->br.link_key);
 		}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2154,7 +2154,7 @@ static void unpair(struct bt_dev *hdev, uint8_t id, const bt_addr_le_t *addr)
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 	struct bt_conn_auth_info_cb *listener, *next;
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->hdev->bt_auth_info_cbs, listener,
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&hdev->bt_auth_info_cbs, listener,
 					  next, node) {
 		if (listener->bond_deleted) {
 			listener->bond_deleted(id, addr);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2325,7 +2325,7 @@ static void hci_encrypt_change(struct bt_dev *hdev, struct net_buf *buf)
 			}
 		}
 
-		if (conn->encrypt) {
+		if (conn->encrypt && conn->br.link_key != NULL) {
 			conn->br.link_key->key_size = bt_conn_read_enc_key_size(conn);
 		}
 	}

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -229,6 +229,7 @@ enum {
 struct bt_keys_link_key {
 	bt_addr_t               addr;
 	uint8_t                 storage_start[0]  __aligned(sizeof(void *));
+	uint8_t	                key_size;
 	uint8_t                 flags;
 	uint8_t                 key_type;
 	uint8_t                 val[16];


### PR DESCRIPTION
PR Description

This PR addresses multiple issues in Bluetooth disable flow, H4 driver, multi-controller adaptation, and bond/link key stability.

Bug Fixes & Improvements

Fix CONFIG_SMP conflict with NuttX

bug: v/60613

Fix bt_disable not working properly

bug: v/64223

Root cause: adapted H4 driver lacked close() implementation, causing abnormal exit.

Fix build error after H4 driver close patch

bug: v/64223

Resolves regression introduced after commit 90c3f40d.

Adapt multi-controller driver open

bug: v/66921

Fix crash when removing bond info after disconnect

bug: v/68845

conn == NULL on disconnect triggered conn->hdev crash.

Classic: Check LK before clearing it

bug: v/69286

Avoid clearing invalid link key after SSP complete but before LK notify.

Fix HCI timeout crash caused by multiple bt_conn_get_info calls

bug: v/69413

Avoid repeated HCI READ_ENCRYPTION_KEY_SIZE blocking; move key_size retrieval to encryption change event.

Fix conn->br.link_key NULL when bonded device limit exceeded

bug: v/71291

Prevent null pointer access in encryption event reporting.

Host: Perform HCI reset in bt_disable()

bug: v/69290

Send HCI reset during disable instead of driver close.

Remove redundant rsp buf handling.

Ref: [zephyrproject-rtos/zephyr#86645](https://github.com/zephyrproject-rtos/zephyr/pull/86645)