### PR TITLE
add spp stack profile implement

### DIFF
--- a/include/zephyr/bluetooth/classic/spp.h
+++ b/include/zephyr/bluetooth/classic/spp.h
@@ -1,0 +1,306 @@
+/** @file
+ *  @brief Bluetooth SPP Protocol handling.
+ */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_SPP_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_SPP_H_
+
+/**
+ * @brief Serial Port Profile (SPP)
+ * @defgroup bt_spp Serial Port Profile (SPP)
+ * @ingroup bluetooth
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+
+#include <zephyr/bluetooth/classic/rfcomm.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+
+struct bt_spp;
+
+enum bt_spp_mode {
+	BT_SPP_MODE_UNKNOWN,
+	BT_SPP_MODE_UUID,
+	BT_SPP_MODE_CHANNEL,
+};
+
+/** @brief SPP profile application callback structure */
+struct bt_spp_ops {
+	/** SPP connection established callback
+	 *
+	 *  If this callback is provided, it will be called when the Serial Port
+	 *  Profile (SPP) connection has been fully established and is ready for
+	 *  data transfer operations.
+	 *
+	 *  At this point:
+	 *  - The RFCOMM channel is active
+	 *  - The SPP object is fully initialized
+	 *  - Data transmission via bt_spp_send() can begin
+	 *
+	 *  @param conn    ACL connection for the SPP link
+	 *  @param spp     Valid SPP connection object
+	 */
+	void (*connected)(struct bt_conn *conn, struct bt_spp *spp);
+
+	/** SPP connection terminated callback
+	 *
+	 *  If this callback is provided, it will be called when the SPP connection
+	 *  has been terminated. This includes both graceful disconnections and any
+	 *  error conditions that caused the link to break.
+	 *
+	 *  Important notes:
+	 *  - The SPP object will be freed immediately after this callback returns
+	 *  - After this callback, the SPP object becomes invalid
+	 *  - All references to this SPP object should be cleared
+	 *
+	 *  @param spp     SPP connection object (will be freed after callback)
+	 */
+	void (*disconnected)(struct bt_spp *spp);
+
+	/** SPP data received callback
+	 *
+	 *  If this callback is provided, it will be called when data has been
+	 *  received over the SPP connection.
+	 *
+	 *  Important considerations:
+	 *  - The data buffer is only valid during the callback execution
+	 *  - If the data needs to be retained, it must be copied by the application
+	 *  - The implementation should process data quickly to avoid flow control issues
+	 *
+	 *  @param spp     SPP connection object that received the data
+	 *  @param buf     Pointer to the received data buffer
+	 */
+	void (*recv)(struct bt_spp *spp, struct net_buf *buf);
+};
+
+struct bt_spp_client {
+	/** @internal SPP SDP discover params */
+	struct bt_sdp_discover_params sdp_discover;
+};
+
+/** @brief SPP server registration context
+ *
+ *  This structure represents a server-side SPP service instance that
+ *  can be registered with the Bluetooth stack. It contains the SDP record
+ *  used for service discovery, the RFCOMM server object used to accept
+ *  incoming connections, an application-provided accept() callback and a
+ *  list node used to link registered servers.
+ */
+struct bt_spp_server {
+	/** Pointer to the SDP record exposed for this server.
+	 *
+	 *  If NULL when registering, the registration will fail. The record must
+	 *  remain valid for the lifetime of the registration.
+	 */
+	struct bt_sdp_record *sdp_record;
+
+	union {
+		/** UUID (service) to discovery remote SPP service */
+		const struct bt_uuid *uuid;
+		/** Rfcomm channel to connect remote SPP server */
+		uint8_t channel;
+	};
+
+	enum bt_spp_mode mode;
+
+	/** RFCOMM server instance.
+	 *
+	 *  Populated/used by the stack to accept incoming RFCOMM connections
+	 *  for this SPP service. Do not modify directly from application code.
+	 */
+	struct bt_rfcomm_server rfcomm_server;
+
+	/** Application accept callback.
+	 *
+	 *  Called by the stack when an incoming RFCOMM connection for this
+	 *  server is pending. The callback should fill the provided spp
+	 *  pointer with a pre-allocated bt_spp instance (or return an error)
+	 *  to accept/reject the connection.
+	 *
+	 *  @param conn    ACL connection for the incoming request
+	 *  @param server  Pointer to this bt_spp_server instance
+	 *  @param spp     Out parameter to receive the accepted bt_spp instance
+	 *
+	 *  @return 0 on success (spp filled), negative error to reject
+	 */
+	int (*accept)(struct bt_conn *conn, struct bt_spp_server *server, struct bt_spp **spp);
+
+	/** Node to link this server into internal server lists. */
+	sys_snode_t node;
+};
+
+struct bt_spp {
+	/** @internal RFCOMM Data Link Connection (DLC) */
+	struct bt_rfcomm_dlc rfcomm_dlc;
+
+	union {
+		/** UUID (service) to discovery remote SPP service */
+		const struct bt_uuid *uuid;
+		/** Rfcomm channel to connect remote SPP server */
+		uint8_t channel;
+	};
+
+	enum bt_spp_mode mode;
+
+	/** @internal ACL connection reference */
+	struct bt_conn *acl_conn;
+
+	/** @internal Connection state (atomic) */
+	atomic_t state;
+
+	/** Application callbacks
+	 *
+	 *  Pointer to the bt_spp_ops table supplied by the application. The
+	 *  stack calls these callbacks to notify about connection, disconnection
+	 *  and received data events.
+	 */
+	const struct bt_spp_ops *ops;
+
+	/** @internal Role-specific context
+	 *
+	 *  Union containing context specific to the role of this SPP instance:
+	 *   - client: SDP discovery parameters and UUID used when initiating a
+	 *             connection to a remote SPP service.
+	 *   - server: server registration and accept callback context for
+	 *             accepted incoming connections.
+	 *
+	 *  Access the appropriate member only when the instance role is known.
+	 */
+	union {
+		struct bt_spp_client client;
+		struct bt_spp_server server;
+	};
+};
+
+/**
+ * @brief Register an SPP server service
+ *
+ * This function registers a Serial Port Profile (SPP) server service with the
+ * Bluetooth stack. The registered service will be discoverable via SDP and
+ * will accept incoming RFCOMM connections on the specified channel.
+ *
+ *
+ * @note The UUID must remain valid for the lifetime of the service registration.
+ *       Typically this should be one of the standard UUIDs defined in the specification.
+ *
+ * @return 0 on successful service registration
+ * @return -EINVAL if:
+ *         - channel is out of valid range (handled internally)
+ * @return -EEXIST if:if a server with the same node/channel/UUID is already
+ *                 registered.
+ */
+int bt_spp_server_register(struct bt_spp_server *server);
+
+/**
+ * @brief Initiate the SPP connection establishment procedure
+ *
+ * Initiate the Serial Port Profile (SPP) connection establishment procedure
+ * on the ACL connection specified by the parameter `conn` using the specific
+ * UUID to identify the SPP service.
+ *
+ * This function performs the following operations:
+ * 1. Checks for an existing SPP connection on the ACL link
+ * 2. Reference the provided UUID for SDP discovery
+ * 3. Initiates SDP discovery to find the RFCOMM channel, then connects to it
+ * 4. Takes a reference to the ACL connection on success
+ *
+ * The SPP object returned by this function represents the ongoing connection
+ * establishment. The actual connection setup will complete asynchronously
+ * through the Bluetooth stack. When the connection is fully established,
+ * the registered callback `connected` will be triggered to notify the
+ * application.
+ *
+ * @note The returned SPP object is only valid for connection management
+ *       until the connection establishment completes. After the `connected`
+ *       callback is triggered, the SPP object becomes fully valid for
+ *       data transfer operations.
+ *
+ * @param conn ACL connection object on which to establish SPP
+ * @param spp Pointer to a pointer that will receive the SPP connection object
+ *
+ * @return Pointer to the SPP connection object on success
+ * @return 0 in case of success or negative value in case of error.
+ */
+
+int bt_spp_connect(struct bt_conn *conn, struct bt_spp *spp);
+
+/**
+ * @brief Send data over an established SPP connection
+ *
+ * This function transmits data over an established Serial Port Profile (SPP)
+ * connection. The transmission is asynchronous and may be subject to flow control
+ * limitations of the underlying RFCOMM layer.
+ *
+ * @note The function must only be called after the connection has been fully
+ *       established (i.e., after the `connected` callback has been triggered).
+ *       Calling this function on a partially established connection will result
+ *       in undefined behavior.
+ *
+ * @param spp  Valid SPP connection object obtained after successful connection
+ * @param buf  Pointer to the data buffer to send
+ *
+ * @return 0 on successful queuing of the data for transmission
+ * @return -EINVAL if:
+ *         - spp is NULL
+ *         - The underlying ACL connection is missing
+ *         - data is NULL (implied by implementation)
+ * @return Other negative RFCOMM error codes on transmission failure
+ */
+int bt_spp_send(struct bt_spp *spp, struct net_buf *buf);
+
+/**
+ * @brief Release an established SPP connection
+ *
+ * Terminate the Serial Port Profile (SPP) connection represented by the
+ * parameter `spp`.
+ *
+ * This function performs the following operations:
+ * 1. Validates the SPP connection object
+ * 2. Initiates disconnection of the underlying RFCOMM DLC channel
+ *
+ * When the disconnection procedure completes, the registered callback
+ * `disconnected` will be triggered to notify the application. After the
+ * `disconnected` callback returns, the SPP object will be freed by the
+ * stack and becomes invalid.
+ *
+ * @warning This function must only be called after the connection has been
+ *          fully established (i.e., after the `connected` callback has been
+ *          triggered). Calling this function on a partially established
+ *          connection will result in undefined behavior.
+ *
+ * @note After this function is called successfully:
+ *       - All interfaces using this SPP object should not be called
+ *       - The object pointer becomes invalid after the `disconnected` callback
+ *       - Any pending data transfers will be aborted
+ *
+ * @param spp SPP connection object to disconnect
+ *
+ * @return 0 on successful disconnection initiation
+ * @return -EINVAL if:
+ *         - spp is NULL
+ *         - The underlying ACL connection is missing
+ * @return Other negative error codes from the RFCOMM layer on disconnection failure
+ */
+int bt_spp_disconnect(struct bt_spp *spp);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_SPP_H_ */

--- a/subsys/bluetooth/Kconfig.logging
+++ b/subsys/bluetooth/Kconfig.logging
@@ -399,6 +399,10 @@ module = BT_SDP
 module-str = "Bluetooth Service Discovery Protocol (SDP)"
 source "$APPSDIR/external/zblue/zblue/subsys/logging/Kconfig.template.log_config_inherit"
 
+module = BT_SPP
+module-str = "Bluetooth Serial Port Profile (SPP)"
+source "subsys/logging/Kconfig.template.log_config_inherit"
+
 endmenu # Bluetooth Classic
 endif # BT_CLASSIC
 

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -36,3 +36,8 @@ zephyr_library_sources_ifdef(
   CONFIG_BT_DID
   did.c
   )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_SPP
+  spp.c
+  )

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -230,6 +230,26 @@ config BT_DEVICE_VERSION
 
 endif # BT_DID
 
+config BT_SPP
+	bool "Bluetooth SPP Profile [EXPERIMENTAL]"
+	select BT_RFCOMM
+	select EXPERIMENTAL
+	help
+	  This option enables the Bluetooth SPP profile
+
+if BT_SPP
+
+config BT_SPP_L2CAP_MTU
+	int "L2CAP MTU for SPP frames"
+	depends on BT_RFCOMM
+	default BT_RFCOMM_L2CAP_MTU
+	range 23 $(INT16_MAX)
+	help
+	  Maximum size of L2CAP PDU for RFCOMM frames.
+	  RX MTU will be truncated to account for the L2CAP PDU header.
+
+endif # BT_SPP
+
 config BT_PAGE_TIMEOUT
 	hex "Bluetooth Page Timeout"
 	default 0x2000

--- a/subsys/bluetooth/host/classic/shell/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/shell/CMakeLists.txt
@@ -5,3 +5,8 @@ zephyr_library_sources(bredr.c)
 zephyr_library_sources_ifdef(CONFIG_BT_RFCOMM rfcomm.c)
 zephyr_library_sources_ifdef(CONFIG_BT_A2DP a2dp.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AVRCP avrcp.c)
+
+zephyr_library_sources_ifdef(
+    CONFIG_BT_SPP
+    spp.c
+  )

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -1,0 +1,508 @@
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/settings/settings.h>
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/classic/spp.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+
+#include <zephyr/shell/shell.h>
+
+#include "host/shell/bt.h"
+#include "common/bt_shell_private.h"
+#include "common/bt_str.h"
+
+#define HELP_NONE "[none]"
+#define DATA_MTU  CONFIG_BT_SPP_L2CAP_MTU
+
+enum {
+	SPP_DISCONNECTED,
+	SPP_REGISTERED,
+	SPP_CONNECTING,
+	SPP_CONNECTED,
+};
+
+static int spp_accept(struct bt_conn *conn, struct bt_spp_server *server, struct bt_spp **spp);
+
+NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_MAX_CONN, BT_L2CAP_BUF_SIZE(CONFIG_BT_SPP_L2CAP_MTU),
+			  16, NULL);
+
+static uint8_t spp_channel;
+static struct net_buf *tx_buf;
+static uint8_t spp_state;
+static union {
+	struct bt_uuid_16 u16;
+	struct bt_uuid_32 u32;
+	struct bt_uuid_128 u128;
+} spp_uuid;
+
+static struct bt_sdp_attribute spp_attrs_channel[] = {
+	BT_SDP_NEW_SERVICE,
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SVCLASS_ID_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+			BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 12),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+			},
+			)
+		},
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 5),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_RFCOMM)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+				&spp_channel
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROFILE_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(0x0102)
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_SERVICE_NAME("Serial Port"),
+};
+
+static struct bt_sdp_record spp_rec_channel = BT_SDP_RECORD(spp_attrs_channel);
+
+static uint8_t spp_uuid_buf[16];
+
+static struct bt_sdp_attribute spp_attrs_uuid128[] = {
+	BT_SDP_NEW_SERVICE,
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SVCLASS_ID_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 17),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UUID128),
+			spp_uuid_buf
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 12),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+			},
+			)
+		},
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 5),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_RFCOMM)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+				&spp_channel
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROFILE_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_SERIAL_PORT_SVCLASS)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(0x0102)
+			},
+			)
+		},
+		)
+	),
+	BT_SDP_SERVICE_NAME("Serial Port"),
+};
+
+static struct bt_sdp_record spp_rec_uuid128 = BT_SDP_RECORD(spp_attrs_uuid128);
+
+static struct bt_spp_server spp_server = {
+	.accept = spp_accept,
+};
+
+static void spp_connected(struct bt_conn *conn, struct bt_spp *spp)
+{
+	spp_state = SPP_CONNECTED;
+
+	bt_shell_print("SPP:%p, conn:%p connected ", spp, conn);
+}
+
+static void spp_disconnected(struct bt_spp *spp)
+{
+	spp_state = SPP_DISCONNECTED;
+
+	bt_shell_print("SPP:%p disconnected", spp);
+}
+
+static void spp_recv(struct bt_spp *spp, struct net_buf *buf)
+{
+	bt_shell_print("SPP:%p, data len:%d", spp, buf->len);
+
+	bt_shell_hexdump(buf->data, buf->len);
+}
+
+static struct bt_spp_ops spp_ops = {
+	.connected = spp_connected,
+	.disconnected = spp_disconnected,
+	.recv = spp_recv,
+};
+
+static struct bt_spp default_spp = {
+	.ops = &spp_ops,
+};
+
+static int spp_accept(struct bt_conn *conn, struct bt_spp_server *server, struct bt_spp **spp)
+{
+	if (spp_state == SPP_CONNECTED) {
+		bt_shell_print("SPP already connected");
+		return -EALREADY;
+	}
+
+	spp_state = SPP_CONNECTED;
+	*spp = &default_spp;
+
+	return 0;
+}
+
+static int spp_uuid_register(const struct shell *sh, int32_t argc, char *argv[])
+{
+	int err;
+	const char *uuid;
+	char hex[33];
+	static uint8_t uuid_buf[16];
+
+	uuid = argv[2];
+
+	if ((strlen(uuid) != 36) || (uuid[8] != '-') || (uuid[13] != '-') || (uuid[18] != '-') ||
+	    (uuid[23] != '-')) {
+		shell_print(sh, "Usage: <uuid128>\nExample: 00001101-0000-1000-8000-00805F9B34FB");
+		return -ENOEXEC;
+	}
+
+	/* remove dashes into contiguous hex string */
+	for (size_t i = 0, j = 0; i < 36; i++) {
+		if (uuid[i] == '-') {
+			continue;
+		}
+
+		hex[j++] = uuid[i];
+	}
+	hex[32] = '\0';
+
+	/* convert 32 hex chars -> 16 bytes into spp_uuid_buf */
+	err = hex2bin(hex, 32, uuid_buf, sizeof(uuid_buf));
+	if (err <= 0) {
+		shell_print(sh, "fail parse uuid hex");
+		return -ENOEXEC;
+	}
+
+	sys_memcpy_swap(spp_uuid_buf, uuid_buf, sizeof(uuid_buf));
+
+	spp_server.sdp_record = &spp_rec_uuid128;
+	spp_server.rfcomm_server.channel = 0;
+
+	err = bt_spp_server_register(&spp_server);
+	if (err < 0) {
+		shell_print(sh, "fail to register SPP service, err:%d", err);
+		spp_server.sdp_record = NULL;
+		spp_server.rfcomm_server.channel = 0U;
+		return -ENOEXEC;
+	}
+
+	spp_channel = spp_server.rfcomm_server.channel;
+
+	shell_print(sh, "register SPP srv uuid:%s(channel:%d) success", uuid, spp_channel);
+
+	return 0;
+}
+
+static int spp_channel_register(const struct shell *sh, int32_t argc, char *argv[])
+{
+	int err = -1;
+
+	spp_channel = strtoul(argv[2], NULL, 16);
+
+	spp_server.sdp_record = &spp_rec_channel;
+	spp_server.rfcomm_server.channel = spp_channel;
+
+	err = bt_spp_server_register(&spp_server);
+	if (err < 0) {
+		shell_print(sh, "fail to register SPP service, err:%d", err);
+		spp_server.sdp_record = NULL;
+		spp_server.rfcomm_server.channel = 0U;
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "register SPP srv channel:%d success", spp_channel);
+
+	return 0;
+}
+
+static int cmd_register_server(const struct shell *sh, int32_t argc, char *argv[])
+{
+	int err = -1;
+	const char *type;
+
+	if (argc < 3) {
+		return -ENOEXEC;
+	}
+
+	type = argv[1];
+
+	if (!strcmp(type, "channel")) {
+		err = spp_channel_register(sh, argc, argv);
+	} else if (!strcmp(type, "uuid")) {
+		err = spp_uuid_register(sh, argc, argv);
+	} else {
+		shell_print(sh, "invalid type:%s", type);
+		return -ENOEXEC;
+	}
+
+	return err;
+}
+
+static int spp_uuid_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	size_t len;
+
+	len = strlen(argv[2]);
+
+	if (len == (BT_UUID_SIZE_16 * 2)) {
+		uint16_t val;
+
+		spp_uuid.u16.uuid.type = BT_UUID_TYPE_16;
+		hex2bin(argv[2], len, (uint8_t *)&val, sizeof(val));
+		spp_uuid.u16.val = sys_be16_to_cpu(val);
+	} else if (len == (BT_UUID_SIZE_32 * 2)) {
+		uint32_t val;
+
+		spp_uuid.u32.uuid.type = BT_UUID_TYPE_32;
+		hex2bin(argv[2], len, (uint8_t *)&val, sizeof(val));
+		spp_uuid.u32.val = sys_be32_to_cpu(val);
+	} else if (len == (BT_UUID_SIZE_128 * 2)) {
+		uint8_t uuid128[BT_UUID_SIZE_128];
+
+		spp_uuid.u128.uuid.type = BT_UUID_TYPE_128;
+		hex2bin(argv[2], len, &uuid128[0], sizeof(uuid128));
+		sys_memcpy_swap(spp_uuid.u128.val, uuid128, sizeof(uuid128));
+	} else {
+		shell_error(sh, "Invalid UUID");
+		return -ENOEXEC;
+	}
+
+	default_spp.mode = BT_SPP_MODE_UUID;
+	default_spp.uuid = (const struct bt_uuid *)&spp_uuid;
+	spp_state = SPP_CONNECTING;
+
+	err = bt_spp_connect(default_conn, &default_spp);
+	if (err < 0) {
+		shell_error(sh, "fail to connect SPP device, err:%d", err);
+		default_spp.mode = BT_SPP_MODE_UNKNOWN;
+		default_spp.uuid = NULL;
+		spp_state = SPP_DISCONNECTED;
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "SPP connect uuid:%s ", bt_uuid_str((const struct bt_uuid *)&spp_uuid));
+	return 0;
+}
+
+static int spp_channel_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	uint8_t channel;
+
+	channel = strtoul(argv[2], NULL, 16);
+
+	default_spp.mode = BT_SPP_MODE_CHANNEL;
+	default_spp.channel = channel;
+	spp_state = SPP_CONNECTING;
+
+	err = bt_spp_connect(default_conn, &default_spp);
+	if (err < 0) {
+		shell_error(sh, "fail to connect SPP device, err:%d", err);
+		default_spp.mode = BT_SPP_MODE_UNKNOWN;
+		default_spp.uuid = NULL;
+		spp_state = SPP_DISCONNECTED;
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "SPP connect channel:%d", channel);
+	return 0;
+}
+
+static int cmd_spp_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	const char *type;
+
+	if (argc < 3) {
+		return -ENOEXEC;
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "please connect bt first");
+		return -ENOEXEC;
+	}
+
+	type = argv[1];
+
+	if (!strcmp(type, "channel")) {
+		err = spp_channel_connect(sh, argc, argv);
+	} else if (!strcmp(type, "uuid")) {
+		err = spp_uuid_connect(sh, argc, argv);
+	} else {
+		shell_print(sh, "invalid type:%s", type);
+		return -ENOEXEC;
+	}
+
+	return err;
+}
+
+static int cmd_spp_send(const struct shell *sh, size_t argc, char *argv[])
+{
+	uint8_t data[DATA_MTU];
+	int len = DATA_MTU;
+	int err;
+
+	memset(data, 0xff, sizeof(data));
+
+	if (spp_state != SPP_CONNECTED) {
+		shell_error(sh, "SPP is not connected");
+		return -ENOEXEC;
+	}
+
+	tx_buf = bt_rfcomm_create_pdu(&tx_pool);
+	if (tx_buf == NULL) {
+		shell_error(sh, "SPP tx_buf is NULL");
+		return -ENOEXEC;
+	}
+
+	if (argc > 1) {
+		len = strtoul(argv[1], NULL, 10);
+	}
+
+	len = MIN(DATA_MTU, len);
+	shell_print(sh, "Send data len:%d", len);
+
+	net_buf_add_mem(tx_buf, data, len);
+
+	err = bt_spp_send(&default_spp, tx_buf);
+	if (err < 0) {
+		shell_error(sh, "fail to send data, err:%d", err);
+		net_buf_unref(tx_buf);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_spp_disconnect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (spp_state != SPP_CONNECTED) {
+		shell_error(sh, "SPP is not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_spp_disconnect(&default_spp);
+	if (err < 0) {
+		shell_error(sh, "fail to disconnect SPP, err:%d", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "SPP disconnecting");
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	spp_cmds,
+	SHELL_CMD_ARG(register, NULL, "register server  <type: channel or uuid> <value>",
+		      cmd_register_server, 3, 0),
+	SHELL_CMD_ARG(connect, NULL, "connect <type: channel or uuid> <value>", cmd_spp_connect, 3,
+		      0),
+	SHELL_CMD_ARG(send, NULL, "send [length of packet(s)]", cmd_spp_send, 2, 1),
+	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_spp_disconnect, 1, 0), SHELL_SUBCMD_SET_END);
+
+static int cmd_spp(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc == 1) {
+		shell_help(sh);
+		/* sh returns 1 when help is printed */
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	shell_error(sh, "%s unknown parameter: %s", argv[0], argv[1]);
+
+	return -ENOEXEC;
+}
+
+SHELL_CMD_ARG_REGISTER(spp, &spp_cmds, "Bluetooth SPP sh commands", cmd_spp, 1, 1);

--- a/subsys/bluetooth/host/classic/spp.c
+++ b/subsys/bluetooth/host/classic/spp.c
@@ -154,6 +154,71 @@ static int bt_spp_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
 	return 0;
 }
 
+static int bt_spp_connect_rfcomm(struct bt_conn *conn, struct bt_spp *spp)
+{
+	int err;
+
+	if ((conn == NULL) || (spp == NULL)) {
+		LOG_ERR("Invalid parameter");
+		return -EINVAL;
+	}
+
+	spp->acl_conn = bt_conn_ref(conn);
+	spp->rfcomm_dlc.ops = &spp_rfcomm_ops;
+	spp->rfcomm_dlc.mtu = SPP_RFCOMM_MTU;
+	spp->rfcomm_dlc.required_sec_level = BT_SECURITY_L2;
+
+	err = bt_rfcomm_dlc_connect(conn, &spp->rfcomm_dlc, spp->channel);
+	if (err < 0) {
+		LOG_ERR("SPP rfcomm dlc connect fail, err:%d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static uint8_t sdp_discover_cb(struct bt_conn *conn, struct bt_sdp_client_result *response,
+			       const struct bt_sdp_discover_params *params)
+{
+	uint16_t channel;
+	int err;
+	struct bt_spp *spp = CONTAINER_OF(params, struct bt_spp, client.sdp_discover);
+
+	if (response == NULL) {
+		LOG_WRN("SPP response is null");
+		return BT_SDP_DISCOVER_UUID_CONTINUE;
+	}
+
+	if (response->resp_buf == NULL) {
+		LOG_ERR("SPP sdp resp_buf is null");
+		goto exit;
+	}
+
+	err = bt_sdp_get_proto_param(response->resp_buf, BT_SDP_PROTO_RFCOMM, &channel);
+	if (err < 0) {
+		LOG_ERR("SPP sdp get proto fail");
+		goto exit;
+	}
+
+	LOG_DBG("SPP SDP record channel:%d found for uuid:%s", channel, bt_uuid_str(params->uuid));
+
+	spp->channel = channel;
+	err = bt_spp_connect_rfcomm(conn, spp);
+	if (err < 0) {
+		LOG_ERR("SPP connect fail, err:%d", err);
+		goto exit;
+	}
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+
+exit:
+	if (spp->ops->disconnected) {
+		spp->ops->disconnected(spp);
+	}
+
+	return BT_SDP_DISCOVER_UUID_STOP;
+}
+
 int bt_spp_server_register(struct bt_spp_server *server)
 {
 	if (!server || (server->accept == NULL) || (server->sdp_record == NULL)) {
@@ -194,15 +259,84 @@ int bt_spp_server_register(struct bt_spp_server *server)
 
 int bt_spp_connect(struct bt_conn *conn, struct bt_spp *spp)
 {
-	return -EOPNOTSUPP;
+	int err;
+
+	if ((spp == NULL) || (spp->mode == BT_SPP_MODE_UNKNOWN) || (spp->ops == NULL)) {
+		LOG_ERR("Invalid parameter");
+		return -EINVAL;
+	}
+
+	if (atomic_get(&spp->state) != SPP_STATE_DISCONNECTED) {
+		LOG_ERR("SPP was not in disconnected state");
+		return -EALREADY;
+	}
+
+	if (spp->mode == BT_SPP_MODE_CHANNEL) {
+		err = bt_spp_connect_rfcomm(conn, spp);
+		if (err < 0) {
+			LOG_ERR("SPP connect fail, err:%d", err);
+			return err;
+		}
+	} else if (spp->mode == BT_SPP_MODE_UUID) {
+		spp->client.sdp_discover.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
+		spp->client.sdp_discover.func = sdp_discover_cb;
+		spp->client.sdp_discover.pool = &sdp_pool;
+		spp->client.sdp_discover.uuid = spp->uuid;
+
+		err = bt_sdp_discover(conn, &spp->client.sdp_discover);
+		if (err < 0) {
+			LOG_ERR("SPP sdp discover fail, err:%d", err);
+			return err;
+		}
+	}
+
+	atomic_set(&spp->state, SPP_STATE_CONNECTING);
+	return 0;
 }
 
 int bt_spp_send(struct bt_spp *spp, struct net_buf *buf)
 {
-	return -EOPNOTSUPP;
+	int err;
+
+	if (spp == NULL) {
+		LOG_ERR("spp or buf invalid");
+		return -EINVAL;
+	}
+
+	if (atomic_get(&spp->state) != SPP_STATE_CONNECTED) {
+		LOG_ERR("Cannot send data while not connected");
+		return -ENOTCONN;
+	}
+
+	err = bt_rfcomm_dlc_send(&spp->rfcomm_dlc, buf);
+	if (err < 0) {
+		LOG_ERR("rfcomm unable to send: %d", err);
+		return err;
+	}
+
+	return 0;
 }
 
 int bt_spp_disconnect(struct bt_spp *spp)
 {
-	return -EOPNOTSUPP;
+	int err;
+
+	if ((spp == NULL) || (spp->acl_conn == NULL)) {
+		LOG_ERR("SPP or conn invalid");
+		return -EINVAL;
+	}
+
+	if (atomic_get(&spp->state) != SPP_STATE_CONNECTED) {
+		LOG_ERR("Cannot disconnect SPP connection while not connected");
+		return -ENOTCONN;
+	}
+
+	err = bt_rfcomm_dlc_disconnect(&spp->rfcomm_dlc);
+	if (err < 0) {
+		LOG_ERR("bt rfcomm disconnect err:%d", err);
+		return err;
+	}
+
+	atomic_set(&spp->state, SPP_STATE_DISCONNECTING);
+	return 0;
 }

--- a/subsys/bluetooth/host/classic/spp.c
+++ b/subsys/bluetooth/host/classic/spp.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <strings.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/classic/rfcomm.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/classic/spp.h>
+
+#include "host/hci_core.h"
+#include "host/conn_internal.h"
+#include "common/bt_str.h"
+
+#include "l2cap_br_internal.h"
+#include "rfcomm_internal.h"
+#include "spp_internal.h"
+
+#define LOG_LEVEL CONFIG_BT_SPP_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_spp);
+
+#define SPP_RFCOMM_MTU     CONFIG_BT_SPP_L2CAP_MTU
+
+K_SEM_DEFINE(spp_lock, 1U, 1U);
+NET_BUF_POOL_FIXED_DEFINE(sdp_pool, CONFIG_BT_MAX_CONN, SDP_CLIENT_BUF_LEN, 8, NULL);
+
+static sys_slist_t spp_rfcomm_server = SYS_SLIST_STATIC_INIT(&spp_rfcomm_server);
+
+static struct bt_spp_server *bt_spp_find_service_by_channel(uint8_t channel)
+{
+	struct bt_spp_server *server;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&spp_rfcomm_server, server, node) {
+		if (server->channel == channel) {
+			return server;
+		}
+	}
+
+	return NULL;
+}
+
+static struct bt_spp_server *bt_spp_find_service_by_uuid(const struct bt_uuid *uuid)
+{
+	struct bt_spp_server *server;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&spp_rfcomm_server, server, node) {
+		if (bt_uuid_cmp(server->uuid, uuid) == 0) {
+			return server;
+		}
+	}
+
+	return NULL;
+}
+
+static void bt_spp_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
+{
+	struct bt_spp *spp = CONTAINER_OF(dlci, struct bt_spp, rfcomm_dlc);
+
+	if (spp->ops->recv) {
+		spp->ops->recv(spp, buf);
+	}
+}
+
+static void bt_spp_connected(struct bt_rfcomm_dlc *dlci)
+{
+	struct bt_spp *spp = CONTAINER_OF(dlci, struct bt_spp, rfcomm_dlc);
+
+	LOG_DBG("SPP %p connected", dlci);
+
+	atomic_set(&spp->state, SPP_STATE_CONNECTED);
+
+	if (spp->ops->connected) {
+		spp->ops->connected(spp->acl_conn, spp);
+	}
+}
+
+static void bt_spp_disconnected(struct bt_rfcomm_dlc *dlci)
+{
+	struct bt_spp *spp = CONTAINER_OF(dlci, struct bt_spp, rfcomm_dlc);
+
+	LOG_DBG("SPP %p disconnected", dlci);
+
+	atomic_set(&spp->state, SPP_STATE_DISCONNECTED);
+
+	if (spp->ops->disconnected) {
+		spp->ops->disconnected(spp);
+	}
+
+	bt_conn_unref(spp->acl_conn);
+	spp->acl_conn = NULL;
+}
+
+static struct bt_rfcomm_dlc_ops spp_rfcomm_ops = {
+	.recv = bt_spp_recv,
+	.connected = bt_spp_connected,
+	.disconnected = bt_spp_disconnected,
+};
+
+static int bt_spp_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
+			 struct bt_rfcomm_dlc **dlc)
+{
+	struct bt_spp_server *rfcomm_server =
+		CONTAINER_OF(server, struct bt_spp_server, rfcomm_server);
+	struct bt_spp *spp = NULL;
+	int err;
+
+	LOG_DBG("accept a spp conn %p", conn);
+
+	k_sem_take(&spp_lock, K_FOREVER);
+	if (!sys_slist_find(&spp_rfcomm_server, &rfcomm_server->node, NULL)) {
+		k_sem_give(&spp_lock);
+		LOG_ERR("SPP server not registered");
+		return -EINVAL;
+	}
+
+	k_sem_give(&spp_lock);
+
+	err = rfcomm_server->accept(conn, rfcomm_server, &spp);
+	if (err < 0) {
+		LOG_ERR("SPP accept callback failed, err:%d", err);
+		return err;
+	}
+
+	if (spp == NULL) {
+		LOG_ERR("SPP accept callback return null spp");
+		return -EINVAL;
+	}
+
+	if (atomic_get(&spp->state) != SPP_STATE_DISCONNECTED) {
+		LOG_ERR("SPP already connected or connecting");
+		return -EALREADY;
+	}
+
+	spp->acl_conn = bt_conn_ref(conn);
+	spp->rfcomm_dlc.ops = &spp_rfcomm_ops;
+	spp->rfcomm_dlc.mtu = SPP_RFCOMM_MTU;
+	spp->rfcomm_dlc.required_sec_level = BT_SECURITY_L2;
+	*dlc = &spp->rfcomm_dlc;
+
+	return 0;
+}
+
+int bt_spp_server_register(struct bt_spp_server *server)
+{
+	if (!server || (server->accept == NULL) || (server->sdp_record == NULL)) {
+		LOG_DBG("Invalid parameter");
+		return -EINVAL;
+	}
+
+	k_sem_take(&spp_lock, K_FOREVER);
+
+	if (sys_slist_find(&spp_rfcomm_server, &server->node, NULL)) {
+		k_sem_give(&spp_lock);
+		LOG_WRN("RFCOMM server has been registered");
+		return -EEXIST;
+	}
+
+	if (bt_spp_find_service_by_channel(server->channel)) {
+		k_sem_give(&spp_lock);
+		LOG_WRN("SPP server channel:%d has been registered", server->channel);
+		return -EEXIST;
+	}
+
+	if (bt_spp_find_service_by_uuid(server->uuid)) {
+		k_sem_give(&spp_lock);
+		LOG_WRN("SPP server channel:%d has been registered", server->channel);
+		return -EEXIST;
+	}
+
+	bt_sdp_register_service(server->sdp_record);
+
+	server->rfcomm_server.accept = bt_spp_accept;
+	bt_rfcomm_server_register(&server->rfcomm_server);
+
+	sys_slist_append(&spp_rfcomm_server, &server->node);
+
+	k_sem_give(&spp_lock);
+	return 0;
+}
+
+int bt_spp_connect(struct bt_conn *conn, struct bt_spp *spp)
+{
+	return -EOPNOTSUPP;
+}
+
+int bt_spp_send(struct bt_spp *spp, struct net_buf *buf)
+{
+	return -EOPNOTSUPP;
+}
+
+int bt_spp_disconnect(struct bt_spp *spp)
+{
+	return -EOPNOTSUPP;
+}

--- a/subsys/bluetooth/host/classic/spp_internal.h
+++ b/subsys/bluetooth/host/classic/spp_internal.h
@@ -1,0 +1,33 @@
+/** @file
+ *  @brief Bluetooth SPP Protocol handling.
+ */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/classic/rfcomm.h>
+
+#define SDP_CLIENT_BUF_LEN 512
+
+enum __packed spp_state {
+	/* SPP_STATE_DISCONNECTED:
+	 * No active SPP connection. Resources are released or not allocated.
+	 */
+	SPP_STATE_DISCONNECTED,
+	/* SPP_STATE_CONNECTING:
+	 * Connection is in progress (e.g., SDP discovery or RFCOMM setup).
+	 * Not yet available for data transfer.
+	 */
+	SPP_STATE_CONNECTING,
+	/* SPP_STATE_CONNECTED:
+	 * RFCOMM DLC is established and SPP is ready for data transfer.
+	 */
+	SPP_STATE_CONNECTED,
+	/* SPP_STATE_DISCONNECTING:
+	 * Disconnection is in progress; cleanup and resource release pending.
+	 */
+	SPP_STATE_DISCONNECTING,
+};


### PR DESCRIPTION
add spp stack profile implement

## Summary

Serial Port Profile (SPP) implementation providing full client/server functionality and comprehensive test tools. The solution enables reliable serial communication over RFCOMM for IoT devices, peripherals, and bridge applications.

## Impact

SPP stack profle

## Testing

local test cleint and server send/recv pass

