### PR TITLE
set gatt signature feature config default to y.

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -532,6 +532,7 @@ config BT_RPA_SHARING
 
 config BT_SIGNING
 	bool "Data signing support"
+	default y
 	help
 	  This option enables data signing which is used for transferring
 	  authenticated data in an unencrypted connection.


### PR DESCRIPTION
bug: v/74050

for PTS:GAP/SEC/CSIGN/BV-01-C

