### PR TITLE
modify bt_buf_acl_tx counts from 3 to 7, fix ctkd key distribution sign key fail.

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -33,9 +33,7 @@ config BT_BUF_ACL_TX_SIZE
 
 config BT_BUF_ACL_TX_COUNT
 	int "Number of outgoing ACL data buffers"
-	default 7 if BT_HCI_RAW
-	default 4 if BT_MESH_GATT
-	default 3
+	default 7
 	range 1 $(UINT8_MAX)
 	help
 	  Number of outgoing ACL data buffers sent from the Host to the


### PR DESCRIPTION
bug: v/77177

During the key distribution phase, 3 L2CAP packets are sent consecutively. When reaching the signature key (sign key) step, the buffer (buf) is already insufficient. The buffer count was then increased to 7, with reference to the Zephyr community project configuration：
<img width="510" height="424" alt="image" src="https://github.com/user-attachments/assets/f3a36ac5-b00c-4aa6-ab58-31af3fec75e9" />

Issue Reproduction Point：
<img width="1234" height="837" alt="image" src="https://github.com/user-attachments/assets/87fbf2a6-5dfa-4ae1-b673-ae3493de0191" />
By default, the ACL TX pool is used. As observed through GDB disassembly:
The `uninit_buf` count is 0, which indicates that the buffers are completely exhausted.
The `buf_count` is 3, meaning there are a total of 3 buffers.

Moreover, BT_L2CAP_TX_BUF_COUNT depends on BT_BUF_ACL_TX_COUNT:
<img width="700" height="121" alt="image" src="https://github.com/user-attachments/assets/390649f6-cf16-4957-8fc9-09e44ce8ee9b" />
