### PR TITLE
add set default link policy hci cmd in br enable procedure.

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -558,6 +558,11 @@ struct bt_hci_cp_io_capability_neg_reply {
 	uint8_t   reason;
 } __packed;
 
+#define BT_HCI_OP_WRITE_DEFAULT_LINK_POLICY_SETTINGS BT_OP(BT_OGF_LINK_POLICY, 0x000f)
+struct bt_hci_cp_write_default_link_policy_settings {
+	uint16_t default_link_policy_settings;
+} __packed;
+
 #define BT_HCI_OP_SNIFF_MODE                    BT_OP(BT_OGF_LINK_POLICY, 0x0003) /* 0x0803 */
 struct bt_hci_cp_sniff_mode {
 	uint16_t handle;
@@ -566,6 +571,10 @@ struct bt_hci_cp_sniff_mode {
 	uint16_t attempt;
 	uint16_t timeout;
 } __packed;
+
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH  BIT(0)
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_HOLD_MODE    BIT(1)
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_SNIFF_SWITCH BIT(2)
 
 #define BT_HCI_OP_EXIT_SNIFF_MODE               BT_OP(BT_OGF_LINK_POLICY, 0x0004) /* 0x0804 */
 struct bt_hci_cp_exit_sniff_mode {

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -860,6 +860,7 @@ int bt_br_init(struct bt_dev *hdev)
 	struct bt_hci_cp_write_inquiry_mode *inq_cp;
 	struct bt_hci_write_local_name *name_cp;
 	struct bt_hci_cp_write_class_of_device *cod;
+	struct bt_hci_cp_write_default_link_policy_settings *policy_cp;
 	int err;
 
 	/* Read extended local features */
@@ -964,6 +965,23 @@ int bt_br_init(struct bt_dev *hdev)
 		if (err) {
 			return err;
 		}
+	}
+
+	/* Set default link policy*/
+	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_DEFAULT_LINK_POLICY_SETTINGS, sizeof(*policy_cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	policy_cp = net_buf_add(buf, sizeof(*policy_cp));
+	policy_cp->default_link_policy_settings =
+		BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH |
+		BT_HCI_LINK_POLICY_SETTINGS_ENABLE_HOLD_MODE |
+		BT_HCI_LINK_POLICY_SETTINGS_ENABLE_SNIFF_SWITCH;
+
+	err = bt_hci_cmd_send_sync(hdev, BT_HCI_OP_WRITE_DEFAULT_LINK_POLICY_SETTINGS, buf, NULL);
+	if (err) {
+		return err;
 	}
 
 	return 0;


### PR DESCRIPTION
bug: v/78281

rootcause: controller may reject role switch when there not be set this, such for earphone reconnect, earphone wants do slave, but role switch not apply for not setting link policy.