### PR TITLE
Bluetooth: Classic: HFP: HF: Report call object when CLCC response.

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -102,6 +102,8 @@ struct bt_hfp_hf_current_call {
 	const char *number;
 	/** Phone number type format identifier */
 	uint8_t type;
+	/** HFP HF call object */
+	struct bt_hfp_hf_call *call;
 };
 
 /** @brief HFP profile application callback */

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -869,6 +869,7 @@ static int clcc_handle(struct at_client *hf_at)
 		current_call.multiparty = mpty > 0 ? true : false;
 		current_call.number = number;
 		current_call.type = (uint8_t)type;
+		current_call.call = call;
 
 		bt_hf->query_call(hf, &current_call);
 	}


### PR DESCRIPTION
bug: v/78002


Report call struct pointer when CLCC response to allow the upper layer to match the call in the response with the pointer provided in the callback.