### PR TITLE
Bluetooth: Host: Fix handling of adv reports when scanning for connection

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -644,13 +644,14 @@ static void le_adv_recv(struct bt_dev *hdev, bt_addr_le_t *addr,
 	struct bt_le_scan_cb *listener, *next;
 	struct net_buf_simple_state state;
 	bt_addr_le_t id_addr;
+	bool explicit_scan = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("dev:%d, %s event %u, len %u, rssi %d dBm", hdev->dev_id, bt_addr_le_str(addr), info->adv_type, len,
 		info->rssi);
 
 	if (!IS_ENABLED(CONFIG_BT_PRIVACY) && !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-	    atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN) &&
-	    (info->adv_props & BT_HCI_LE_ADV_PROP_DIRECT)) {
+	    explicit_scan && (info->adv_props & BT_HCI_LE_ADV_PROP_DIRECT)) {
 		LOG_DBG("Dropped direct adv report");
 		return;
 	}
@@ -662,6 +663,13 @@ static void le_adv_recv(struct bt_dev *hdev, bt_addr_le_t *addr,
 	} else {
 		bt_addr_le_copy(&id_addr,
 				bt_lookup_id_addr(hdev, BT_ID_DEFAULT, addr));
+	}
+
+	/* For connection-purpose scanning,
+	 * skip app callbacks but allow pending-conn check logic.
+	 */
+	if (!explicit_scan && conn_scan) {
+		goto check_pending_conn;
 	}
 
 	if (hdev->scan_ctx->scan_dev_found_cb) {
@@ -689,6 +697,7 @@ static void le_adv_recv(struct bt_dev *hdev, bt_addr_le_t *addr,
 	/* Clear pointer to this stack frame before returning to calling function */
 	info->addr = NULL;
 
+check_pending_conn:
 #if defined(CONFIG_BT_CENTRAL)
 	check_pending_conn(hdev, &id_addr, addr, info->adv_props);
 #endif /* CONFIG_BT_CENTRAL */
@@ -788,6 +797,8 @@ static void create_ext_adv_info(struct bt_hci_evt_le_ext_advertising_info const 
 void bt_hci_le_adv_ext_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
+	bool explicit_scan = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u", num_reports);
 
@@ -800,19 +811,23 @@ void bt_hci_le_adv_ext_report(struct bt_dev *hdev, struct net_buf *buf)
 		bool more_to_come;
 		bool is_new_advertiser;
 
-		if (!atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+		if (!explicit_scan) {
 			/* The application has not requested explicit scan, so it is not expecting
 			 * advertising reports. Discard, and reset the reassembler if not inactive
 			 * This is done in the loop as this flag can change between each iteration,
 			 * and it is not uncommon that scanning is disabled in the callback called
-			 * from le_adv_recv
+			 * from le_adv_recv.
+			 *
+			 * However, if scanning is running for connection purposes,
+			 * the report shall still be processed to allow pending connections.
 			 */
-
 			if (hdev->scan_ctx->reassembling_advertiser.state != FRAG_ADV_INACTIVE) {
 				reset_reassembling_advertiser(hdev);
 			}
 
-			break;
+			if (!conn_scan) {
+				break;
+			}
 		}
 
 		if (buf->len < sizeof(*evt)) {
@@ -1669,18 +1684,23 @@ void bt_hci_le_adv_report(struct bt_dev *hdev, struct net_buf *buf)
 {
 	uint8_t num_reports = net_buf_pull_u8(buf);
 	struct bt_hci_evt_le_advertising_info *evt;
+	bool explicit_scan = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN);
+	bool conn_scan     = atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_CONN);
 
 	LOG_DBG("Adv number of reports %u",  num_reports);
 
 	while (num_reports--) {
 		struct bt_le_scan_recv_info adv_info;
 
-		if (!atomic_test_bit(hdev->scan_ctx->scan_state.scan_flags, BT_LE_SCAN_USER_EXPLICIT_SCAN)) {
+		if (!explicit_scan && !conn_scan) {
 			/* The application has not requested explicit scan, so it is not expecting
 			 * advertising reports. Discard.
 			 * This is done in the loop as this flag can change between each iteration,
 			 * and it is not uncommon that scanning is disabled in the callback called
-			 * from le_adv_recv
+			 * from le_adv_recv.
+			 *
+			 * However, if scanning is running for connection purposes,
+			 * the report shall still be processed to allow pending connections.
 			 */
 
 			break;

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -550,7 +550,6 @@ int bt_le_scan_user_remove(struct bt_dev *hdev, enum bt_le_scan_user flag)
 	return scan_update(hdev);
 }
 
-#if defined(CONFIG_BT_CENTRAL)
 static void check_pending_conn(struct bt_dev *hdev, const bt_addr_le_t *id_addr,
 			       const bt_addr_le_t *addr, uint8_t adv_props)
 {
@@ -605,7 +604,6 @@ failed:
 		LOG_WRN("Error while updating the scanner (%d)", err);
 	}
 }
-#endif /* CONFIG_BT_CENTRAL */
 
 /* Convert Legacy adv report evt_type field to adv props */
 static uint8_t get_adv_props_legacy(uint8_t evt_type)
@@ -668,7 +666,7 @@ static void le_adv_recv(struct bt_dev *hdev, bt_addr_le_t *addr,
 	/* For connection-purpose scanning,
 	 * skip app callbacks but allow pending-conn check logic.
 	 */
-	if (!explicit_scan && conn_scan) {
+	if (IS_ENABLED(CONFIG_BT_CENTRAL) && !explicit_scan && conn_scan) {
 		goto check_pending_conn;
 	}
 
@@ -698,9 +696,9 @@ static void le_adv_recv(struct bt_dev *hdev, bt_addr_le_t *addr,
 	info->addr = NULL;
 
 check_pending_conn:
-#if defined(CONFIG_BT_CENTRAL)
-	check_pending_conn(hdev, &id_addr, addr, info->adv_props);
-#endif /* CONFIG_BT_CENTRAL */
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		check_pending_conn(hdev, &id_addr, addr, info->adv_props);
+	}
 }
 
 #if defined(CONFIG_BT_EXT_ADV)


### PR DESCRIPTION
bug: v/78367

In some cases, the host starts scanning internally for establishing
connections (BT_LE_SCAN_USER_CONN), such as host-based resolving or
auto-connection. In this situation, even if the application does not
start explicit scan, the host still needs to handle the advertising
reports to continue the connection process.

Previously, both bt_hci_le_adv_report() and bt_hci_le_adv_ext_report()
will break or discard all reports when explicit scan is not active.
This causes the connection to stay in SCAN_BEFORE_INITIATING and never
move forward.

This patch adds checking of BT_LE_SCAN_USER_CONN to allow advertising
reports to be processed during connection-purpose scanning. When the
scan is started explicitly by application, the behavior remains the
same, only small comments are updated to describe this behavior and keep
the original code style unchanged.

This PR is cherry-pick from 
https://github.com/zephyrproject-rtos/zephyr/pull/98411
https://github.com/zephyrproject-rtos/zephyr/pull/98859