### PR TITLE
host: gatt: Support deferred Read and Write Response handling

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1941,7 +1941,7 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
  *  @param conn   Connection object.
  *  @param err    Error value created with BT_GATT_ERR() using a specific
  *                BT_ATT_ERR_* code, or 0 for success.
- *  @param attr   The attribute that's being read.
+ *  @param handle The attribute handle that's being read.
  *  @param data   Pointer to the attribute value buffer.
  *  @param length Length of the attribute value.
  *
@@ -1952,7 +1952,7 @@ int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
  *  @retval -ENOMEM Out of memory.
  *  @retval -ENOTSUP EATT deferred responses not supported.
  */
-int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, uint16_t handle,
 			      const void *data, uint16_t length);
 
 struct bt_gatt_write_params;
@@ -2021,7 +2021,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  @param conn   Connection object.
  *  @param err    Error value created with BT_GATT_ERR() using a specific
  *                BT_ATT_ERR_* code, or 0 for success.
- *  @param attr  The attribute that's being written.
+ *  @param handle The attribute handle that's being written.
  *
  *  @retval 0 Successfully queued response.
  *
@@ -2030,7 +2030,7 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
  *  @retval -ENOMEM Out of memory.
  *  @retval -ENOTSUP EATT deferred responses not supported.
  */
-int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr);
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, uint16_t handle);
 
 /** @brief Write Attribute Value by handle without response with callback.
  *

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -147,6 +147,18 @@ struct bt_gatt_attr;
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
  *
+ *  @note If this function returns ``-EINPROGRESS``, the read operation
+ *  is deferred and the application must later send the response
+ *  using @ref bt_gatt_send_read_rsp(). Deferred responses are only
+ *  supported when no EATT bearers are established for this connection.
+ *
+ *  @note The application must send the deferred response before the ATT
+ *  timeout expires, otherwise the bearer will be terminated.
+ *
+ *  @note The @p buf pointer is only valid for the duration of this call,
+ *  and must not be accessed after the function returns, even when
+ *  returning ``-EINPROGRESS``.
+ *
  *  @param conn   The connection that is requesting to read.
  *                NULL if local.
  *  @param attr   The attribute that's being read
@@ -189,6 +201,24 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *
  *  @note The GATT server propagates the return value from this
  *  method back to the remote client.
+ *
+ *  @note If this function returns ``-EINPROGRESS``, the write operation
+ *  is deferred and the application must later send the response using
+ *  @ref bt_gatt_send_write_rsp(). Deferred responses are only supported
+ *  for regular Write Requests; returning ``-EINPROGRESS`` is not valid
+ *  for Write Commands (@ref BT_GATT_WRITE_FLAG_CMD), Prepare Writes
+ *  (@ref BT_GATT_WRITE_FLAG_PREPARE), or Execute Writes
+ *  (@ref BT_GATT_WRITE_FLAG_EXECUTE).
+ *
+ *  @note Deferred write responses are only supported when no EATT bearers
+ *  are established for this connection.
+ *
+ *  @note The application must send the deferred response before the ATT
+ *  timeout expires, otherwise the bearer will be terminated.
+ *
+ *  @note The @p buf pointer is only valid for the duration of this call,
+ *  and must not be accessed after the function returns, even when
+ *  returning ``-EINPROGRESS``.
  *
  *  @param conn   The connection that is requesting to write
  *  @param attr   The attribute that's being written
@@ -1899,6 +1929,32 @@ struct bt_gatt_read_params {
  */
 int bt_gatt_read(struct bt_conn *conn, struct bt_gatt_read_params *params);
 
+/** @brief Send a deferred Read Response
+ *
+ *  Used when an attribute read request was deferred (attr->read returned
+ *  -EINPROGRESS). The application later completes the read operation
+ *  by providing either a value (success) or error code via this API.
+ *
+ *  Deferred responses are only supported when no EATT bearers are
+ *  established for this connection.
+ *
+ *  @param conn   Connection object.
+ *  @param err    Error value created with BT_GATT_ERR() using a specific
+ *                BT_ATT_ERR_* code, or 0 for success.
+ *  @param attr   The attribute that's being read.
+ *  @param data   Pointer to the attribute value buffer.
+ *  @param length Length of the attribute value.
+ *
+ *  @retval 0 Successfully queued response.
+ *
+ *  @retval -ENOTCONN The connection is not established.
+ *  @retval -EINVAL Invalid parameters.
+ *  @retval -ENOMEM Out of memory.
+ *  @retval -ENOTSUP EATT deferred responses not supported.
+ */
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+			      const void *data, uint16_t length);
+
 struct bt_gatt_write_params;
 
 /** @typedef bt_gatt_write_func_t
@@ -1951,6 +2007,30 @@ struct bt_gatt_write_params {
  *  controlled by @kconfig{CONFIG_BT_ATT_TX_COUNT}.
  */
 int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params);
+
+/**
+ *  @brief Send a deferred Write Response
+ *
+ *  Used when an attribute write request was deferred (attr->write returned
+ *  -EINPROGRESS). The application later completes the write operation
+ *  by providing either a success response or an error code via this API.
+ *
+ *  Deferred responses are only supported when no EATT bearers are
+ *  established for this connection.
+ *
+ *  @param conn   Connection object.
+ *  @param err    Error value created with BT_GATT_ERR() using a specific
+ *                BT_ATT_ERR_* code, or 0 for success.
+ *  @param attr  The attribute that's being written.
+ *
+ *  @retval 0 Successfully queued response.
+ *
+ *  @retval -ENOTCONN The connection is not established.
+ *  @retval -EINVAL Invalid parameters.
+ *  @retval -ENOMEM Out of memory.
+ *  @retval -ENOTSUP EATT deferred responses not supported.
+ */
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr);
 
 /** @brief Write Attribute Value by handle without response with callback.
  *

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1399,6 +1399,11 @@ static ssize_t att_chan_read(struct bt_att_chan *chan,
 
 		read = attr->read(conn, attr, frag->data + frag->len, len,
 				  offset);
+
+		if (read == -EINPROGRESS) {
+			return -EINPROGRESS;
+		}
+
 		if (read < 0) {
 			if (total) {
 				return total;
@@ -1578,6 +1583,7 @@ struct read_data {
 	uint16_t offset;
 	struct net_buf *buf;
 	uint8_t err;
+	bool async;
 };
 
 static uint8_t read_cb(const struct bt_gatt_attr *attr, uint16_t handle,
@@ -1610,6 +1616,12 @@ static uint8_t read_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 
 	/* Read attribute value and store in the buffer */
 	ret = att_chan_read(chan, attr, data->buf, data->offset, NULL, NULL);
+
+	if (ret == -EINPROGRESS) {
+		data->async = true;
+		return BT_GATT_ITER_STOP;
+	}
+
 	if (ret < 0) {
 		data->err = err_to_att(ret);
 		return BT_GATT_ITER_STOP;
@@ -1656,6 +1668,12 @@ static uint8_t att_read_rsp(struct bt_att_chan *chan, uint8_t op, uint8_t rsp,
 		net_buf_unref(data.buf);
 		/* Respond here since handle is set */
 		send_err_rsp(chan, op, handle, data.err);
+		return 0;
+	}
+
+	if (data.async) {
+		net_buf_unref(data.buf);
+		/* Async read: release buffer, app send response later */
 		return 0;
 	}
 
@@ -2025,6 +2043,7 @@ struct write_data {
 	uint16_t len;
 	uint16_t offset;
 	uint8_t err;
+	bool async;
 };
 
 static bool attr_write_authorize(struct bt_conn *conn,
@@ -2075,6 +2094,12 @@ static uint8_t write_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	/* Write attribute value */
 	write = attr->write(data->conn, attr, data->value, data->len,
 			    data->offset, flags);
+
+	if (write == -EINPROGRESS) {
+		data->async = true;
+		return BT_GATT_ITER_STOP;
+	}
+
 	if (write < 0 || write != data->len) {
 		data->err = err_to_att(write);
 		return BT_GATT_ITER_STOP;
@@ -2131,6 +2156,12 @@ static uint8_t att_write_rsp(struct bt_att_chan *chan, uint8_t req, uint8_t rsp,
 			send_err_rsp(chan, req, handle, data.err);
 		}
 		return req == BT_ATT_OP_EXEC_WRITE_REQ ? data.err : 0;
+	}
+
+	if (data.async) {
+		net_buf_unref(data.buf);
+		/* Async write: release buffer, app send response later */
+		return 0;
 	}
 
 	if (data.buf) {

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5255,6 +5255,115 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 	return bt_att_send(conn, buf);
 }
 
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+			      const void *data, uint16_t length)
+{
+	struct net_buf *buf;
+	__maybe_unused uint8_t att_err;
+	__maybe_unused size_t err_rsp_len =
+		sizeof(uint8_t)  +  /* request opcode    */
+		sizeof(uint16_t) +  /* attribute handle  */
+		sizeof(uint8_t);    /* ATT error code    */
+
+	__ASSERT(conn, "invalid connection\n");
+	__ASSERT(attr, "invalid parameter\n");
+	__ASSERT(err <= 0, "invalid error code\n");
+
+	if (conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+#if defined(CONFIG_BT_EATT)
+	if (bt_eatt_count(conn) > 0) {
+		LOG_WRN("EATT active: async response not supported");
+		return -ENOTSUP;
+	}
+#endif
+
+	if (err != 0U) {
+		att_err = (uint8_t)(-err);
+
+		buf = bt_att_create_pdu(conn, BT_ATT_OP_ERROR_RSP, err_rsp_len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		net_buf_add_u8(buf, BT_ATT_OP_READ_REQ);
+		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_u8(buf, att_err);
+
+		LOG_DBG("conn %p error 0x%02x, handle 0x%04x",
+				conn, att_err, attr->handle);
+
+		return bt_att_send(conn, buf);
+	}
+
+	buf = bt_att_create_pdu(conn, BT_ATT_OP_READ_RSP, length);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	if (data != NULL && length != 0U) {
+		net_buf_add_mem(buf, data, length);
+	}
+
+	LOG_DBG("conn %p len %u, handle 0x%04x", conn, length, attr->handle);
+
+	return bt_att_send(conn, buf);
+}
+
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr)
+{
+	struct net_buf *buf;
+	__maybe_unused uint8_t att_err;
+	__maybe_unused size_t err_rsp_len =
+		sizeof(uint8_t)  +  /* request opcode    */
+		sizeof(uint16_t) +  /* attribute handle  */
+		sizeof(uint8_t);    /* ATT error code    */
+
+	__ASSERT(conn, "invalid connection\n");
+	__ASSERT(attr, "invalid parameter\n");
+	__ASSERT(err <= 0, "invalid error code\n");
+
+	if (conn->state != BT_CONN_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+#if defined(CONFIG_BT_EATT)
+	if (bt_eatt_count(conn) > 0) {
+		LOG_WRN("EATT active: async write response not supported");
+		return -ENOTSUP;
+	}
+#endif
+
+	if (err != 0U) {
+		att_err = (uint8_t)(-err);
+
+		buf = bt_att_create_pdu(conn, BT_ATT_OP_ERROR_RSP, err_rsp_len);
+		if (buf == NULL) {
+			return -ENOMEM;
+		}
+
+		net_buf_add_u8(buf, BT_ATT_OP_WRITE_REQ);
+		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_u8(buf, att_err);
+
+		LOG_DBG("conn %p write err 0x%02x, handle 0x%04x",
+				conn, att_err, attr->handle);
+
+		return bt_att_send(conn, buf);
+	}
+
+	buf = bt_att_create_pdu(conn, BT_ATT_OP_WRITE_RSP, 0);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	LOG_DBG("conn %p, handle 0x%04x", conn, attr->handle);
+
+	return bt_att_send(conn, buf);
+}
+
 static int gatt_exec_encode(struct net_buf *buf, size_t len, void *user_data)
 {
 	struct bt_att_exec_write_req *req;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5255,7 +5255,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 	return bt_att_send(conn, buf);
 }
 
-int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr,
+int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, uint16_t handle,
 			      const void *data, uint16_t length)
 {
 	struct net_buf *buf;
@@ -5266,7 +5266,6 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		sizeof(uint8_t);    /* ATT error code    */
 
 	__ASSERT(conn, "invalid connection\n");
-	__ASSERT(attr, "invalid parameter\n");
 	__ASSERT(err <= 0, "invalid error code\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {
@@ -5289,11 +5288,11 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		}
 
 		net_buf_add_u8(buf, BT_ATT_OP_READ_REQ);
-		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_le16(buf, handle);
 		net_buf_add_u8(buf, att_err);
 
 		LOG_DBG("conn %p error 0x%02x, handle 0x%04x",
-				conn, att_err, attr->handle);
+				conn, att_err, handle);
 
 		return bt_att_send(conn, buf);
 	}
@@ -5307,12 +5306,12 @@ int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, const struct bt_gatt_at
 		net_buf_add_mem(buf, data, length);
 	}
 
-	LOG_DBG("conn %p len %u, handle 0x%04x", conn, length, attr->handle);
+	LOG_DBG("conn %p len %u, handle 0x%04x", conn, length, handle);
 
 	return bt_att_send(conn, buf);
 }
 
-int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_attr *attr)
+int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, uint16_t handle)
 {
 	struct net_buf *buf;
 	__maybe_unused uint8_t att_err;
@@ -5322,7 +5321,6 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		sizeof(uint8_t);    /* ATT error code    */
 
 	__ASSERT(conn, "invalid connection\n");
-	__ASSERT(attr, "invalid parameter\n");
 	__ASSERT(err <= 0, "invalid error code\n");
 
 	if (conn->state != BT_CONN_CONNECTED) {
@@ -5345,11 +5343,11 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		}
 
 		net_buf_add_u8(buf, BT_ATT_OP_WRITE_REQ);
-		net_buf_add_le16(buf, attr->handle);
+		net_buf_add_le16(buf, handle);
 		net_buf_add_u8(buf, att_err);
 
 		LOG_DBG("conn %p write err 0x%02x, handle 0x%04x",
-				conn, att_err, attr->handle);
+				conn, att_err, handle);
 
 		return bt_att_send(conn, buf);
 	}
@@ -5359,7 +5357,7 @@ int bt_gatt_send_write_rsp(struct bt_conn *conn, int err, const struct bt_gatt_a
 		return -ENOMEM;
 	}
 
-	LOG_DBG("conn %p, handle 0x%04x", conn, attr->handle);
+	LOG_DBG("conn %p, handle 0x%04x", conn, handle);
 
 	return bt_att_send(conn, buf);
 }


### PR DESCRIPTION
Now the stack handles read_request with a synchronous callback which
requires the value and length to be returned immediately.

This patch enhances the GATT server implementation to support deferred
response handling for both Read and Write operations. It enables
applications to perform long-running or context-dependent attribute
operations without blocking the protocol layer.