### PR TITLE
support ctkd bond state report for openvela framewrok/service arch.

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2587,6 +2587,17 @@ struct bt_conn_auth_info_cb {
 	 */
 	void (*link_key_notify)(struct bt_conn *conn, uint8_t *key, uint8_t key_type);
 #endif
+	/** @brief notify that pairing procedure was complete (with CTKD info).
+	 *
+	 *  Notifies that pairing is done, and whether the key was derived
+	 *  through CTKD.
+	 *
+	 *  @param conn Connection object.
+	 *  @param is_link_key True if the generated key is a BR/EDR Link Key,
+     *                     false if it is an LE LTK.
+	 */
+	void (*pairing_complete_ctkd)(struct bt_conn *conn, bool is_link_key);
+
 	/** @brief notify that pairing procedure was complete.
 	 *
 	 *  This callback notifies the application that the pairing procedure

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -799,6 +799,8 @@ static void sc_derive_link_key(struct bt_smp *smp)
 	struct bt_conn *conn = smp->chan.chan.conn;
 	struct bt_keys_link_key *link_key;
 	uint8_t ilk[16];
+	struct bt_conn_auth_info_cb *listener, *next;
+	bool bond_flag = atomic_test_bit(smp->flags, SMP_FLAG_BOND);
 
 	LOG_DBG("");
 
@@ -861,9 +863,16 @@ static void sc_derive_link_key(struct bt_smp *smp)
 		link_key->flags &= ~BT_LINK_KEY_AUTHENTICATED;
 	}
 
-	if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
+	if (bond_flag) {
 		/* Store the link key */
 		bt_keys_link_key_store(conn->hdev, link_key);
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->hdev->bt_auth_info_cbs, listener,
+							next, node) {
+			if (listener->pairing_complete_ctkd) {
+				/* Derive BR Link Key over LE link */
+				listener->pairing_complete_ctkd(conn, true);
+			}
+		}
 	}
 }
 
@@ -958,9 +967,9 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->hdev->bt_auth_info_cbs, listener,
 						  next, node) {
-			if (listener->pairing_complete) {
-				listener->pairing_complete(smp->chan.chan.conn,
-							   bond_flag);
+			if (listener->pairing_complete_ctkd && bond_flag) {
+				/* Derive LE LTK over BR conn */
+				listener->pairing_complete_ctkd(conn, false);
 			}
 		}
 	}


### PR DESCRIPTION
depends_on[open-vela/frameworks_bluetooth/pull/271]