### PR TITLE
Bluetooth: Classic: HFP: HF: Add send vendor API and callback

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -501,6 +501,17 @@ struct bt_hfp_hf_cb {
 	 *  @param call Current call information.
 	 */
 	void (*query_call)(struct bt_hfp_hf *hf, struct bt_hfp_hf_current_call *call);
+
+	/** @brief Vendor specific command callback
+	 * 
+	 * If this callback is provided it will be called whenever the
+	 * vendor specific command is received from AG.
+	 * If thr request if finished, the callback will be called with a null response.
+	 * 
+	 * @param hf HFP HF object.
+	 * @param response Vendor specific response string.
+	 */
+	void (*vendor_specific)(struct bt_hfp_hf *hf, const char *response);
 };
 
 /** @brief Register HFP HF profile
@@ -1048,6 +1059,15 @@ int Z_API(bt_hfp_hf_battery)(struct bt_hfp_hf *hf, uint8_t level);
  *  @return 0 in case of success or negative value in case of error.
  */
 int Z_API(bt_hfp_hf_query_list_of_current_calls)(struct bt_hfp_hf *hf);
+
+/** @brief Handsfree HF send vendor specific command
+ * 
+ * It allows HF to send vendor specific command to AG.
+ * 
+ * @param hf HFP HF object.
+ * @param cmd Vendor specific command string.
+ */
+int Z_API(bt_hfp_hf_send_vendor)(struct bt_hfp_hf *hf, char* cmd);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -276,6 +276,49 @@ int hfp_hf_send_cmd(struct bt_hfp_hf *hf, at_resp_cb_t resp,
 	return 0;
 }
 
+int vendor_handle(struct at_client *hf_at)
+{
+	char *val;
+
+	val = at_get_string(hf_at);
+	if (!val) {
+		LOG_ERR("Error getting value");
+		return 0;
+	}
+
+	LOG_DBG("Vendor specific value: %s", log_strdup(val));
+
+	return 0;
+}
+
+int vendor_resp(struct at_client *hf_at, struct net_buf *buf)
+{
+	LOG_DBG("Vendor specific response received");
+
+	int err = at_parse_cmd_input(hf_at, buf, "VENDOR", vendor_handle,
+		AT_CMD_TYPE_NORMAL);
+
+	return err;
+}
+
+int vendor_finish(struct at_client *hf_at, enum at_result result,
+		          enum at_cme cme_err)
+{
+	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
+	LOG_DBG("Vendor specific response received");
+
+	bt_hf->vendor_specific(hf, NULL);
+
+	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_VENDOR_PENDING);
+
+	return 0;
+}
+
+int bt_hfp_hf_send_vendor(struct bt_hfp_hf *hf, char* cmd) {
+	int err = hfp_hf_send_cmd(hf, vendor_resp, vendor_finish, "%s", cmd);
+	return err;
+}
+
 int brsf_handle(struct at_client *hf_at)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);

--- a/subsys/bluetooth/host/classic/hfp_hf_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_hf_internal.h
@@ -147,6 +147,7 @@ enum {
 	BT_HFP_HF_FLAG_QUERY_CALLS,   /* Require to query list of current calls */
 	BT_HFP_HF_FLAG_USR_CLCC_CMD,  /* User-initiated AT+CLCC command */
 	BT_HFP_HF_FLAG_USR_CLCC_PND,  /* User-initiated AT+CLCC command is pending */
+	BT_HFP_HF_FLAG_VENDOR_PENDING,/* Vendor specific command is pending */
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_HF_NUM_FLAGS,
 };


### PR DESCRIPTION
bug: v/78306

Rootcause: Add sendvendor API to send vendor-specific AT commands.

