### PR TITLE
ACL: Stop clearing user_data in acl_get_and_clear_cb.

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -997,7 +997,6 @@ static void acl_get_and_clear_cb(struct bt_conn *conn, struct net_buf *buf,
 
 	*cb = closure_cb(buf->user_data);
 	*ud = closure_data(buf->user_data);
-	memset(buf->user_data, 0, buf->user_data_size);
 }
 #endif	/* defined(CONFIG_BT_CONN) */
 


### PR DESCRIPTION
bug: v/75682

due to: https://github.com/open-vela/external_zblue/pull/48/commits/340ff78fa95b1b7c11668d0165cf7b88c47fb09b

The lifecycle of user_data is now managed by higher layers (e.g. ATT, ISO). Clearing user_data at ACL layer causes meta data loss (e.g. bt_att_tx_meta_data). This patch removes the memset to avoid overwriting upper layer metadata, When the buff is re used, the memset clean will again, so it is safe change here.