### PR TITLE
zblue: port: rename API call to fix complie issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3180,7 +3180,7 @@ static void bt_hfp_ag_vr_activate(struct bt_hfp_ag *ag, void *user_data)
 	if (bt_ag && bt_ag->voice_recognition) {
 		bt_ag->voice_recognition(ag, true);
 	} else {
-		(void)bt_hfp_ag_audio_connect(ag, BT_HFP_AG_CODEC_CVSD);
+		(void)Z_API(bt_hfp_ag_audio_connect)(ag, BT_HFP_AG_CODEC_CVSD);
 	}
 #endif /* CONFIG_BT_HFP_AG_VOICE_RECG */
 


### PR DESCRIPTION
bug: v/74979

Rootcause: bt_hfp_ag_vr_activate call bt_hfp_ag_audio_connect without using new Z_API marco.

