### PR TITLE
Fix BR inquiry early EIR drop and discovery callback reset issue

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1079,7 +1079,7 @@ int bt_br_discovery_stop_mc(uint8_t dev_id)
 
 	err = bt_hci_cmd_send_sync(hdev, BT_HCI_OP_INQUIRY_CANCEL, NULL, NULL);
 	if (err) {
-		return err;
+		LOG_ERR("Failed to cancel inquiry (err %d)", err);
 	}
 
 	for (i = 0; i < hdev->discovery_results_count; i++) {
@@ -1110,7 +1110,7 @@ int bt_br_discovery_stop_mc(uint8_t dev_id)
 	hdev->discovery_results_size = 0;
 	hdev->discovery_results_count = 0;
 
-	return 0;
+	return err;
 }
 
 void bt_br_discovery_cb_register_mc(uint8_t dev_id, struct bt_br_discovery_cb *cb)

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -349,7 +349,6 @@ static bool eir_has_name(const uint8_t *eir)
 
 void bt_br_discovery_reset(struct bt_dev *hdev)
 {
-	sys_slist_init(&hdev->discovery_cbs);
 	hdev->discovery_results = NULL;
 	hdev->discovery_results_size = 0;
 	hdev->discovery_results_count = 0;


### PR DESCRIPTION
bug: v/76643

In some cases, Extended Inquiry Result (EIR) may be received earlier than Inquiry status event in the stack. At that time, BT_DEV_INQUIRY flag is not set yet, so EIR data is blocked and cannot be reported to upper layer( have atomic_test_bits ), to permit clear inquiry flag although there is not in inquiry procedure (controller reply command disallowed).

Another issue is In a case, name resolving is no need in 'report_discovery_results' and  discovery reset will
clear inquiry callbacks. This causes all later inquiry callbacks to be lost (next time start inquiry),
which is incorrect. Patch avoids clear inquiry callbacks in such scenarios.