### PR TITLE
sdp: avoid service list cycles and unregister dead loops

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1463,6 +1463,7 @@ int bt_sdp_register_service_mc(uint8_t dev_id, struct bt_sdp_record *service)
 {
 	uint32_t handle = SDP_SERVICE_HANDLE_BASE;
 	struct bt_dev *hdev = bt_dev_get(dev_id);
+	struct bt_sdp_record *tmp;
 
 	if (!hdev) {
 		LOG_ERR("Invalid device id %u", dev_id);
@@ -1472,6 +1473,13 @@ int bt_sdp_register_service_mc(uint8_t dev_id, struct bt_sdp_record *service)
 	if (!service) {
 		LOG_ERR("No service record specified");
 		return 0;
+	}
+
+	for (tmp = hdev->sdp_ctx->db; tmp != NULL; tmp = tmp->next) {
+		if (tmp == service) {
+			LOG_ERR("SDP service already registered: %p", service);
+			return -EALREADY;
+		}
 	}
 
 	if (hdev->sdp_ctx->num_services == BT_SDP_MAX_SERVICES) {
@@ -1525,6 +1533,8 @@ int bt_sdp_unregister_service_mc(uint8_t dev_id, struct bt_sdp_record *service)
 		node->index--;
 		node = node->next;
 	}
+
+	service->next = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
bug: v/79703

  node = &head;
  while (node->next && node->next != service) {
      node = node->next;
  }

- In bt_sdp_register_service_mc():
  * Reject records whose service->next is already non‑NULL. This means the record is already linked into some list; reusing it as the new head would splice lists together or create a cycle.
  * Reject registrations where hdev->sdp_ctx->db == service. This means the same record is already the current DB head; pushing it again as head would make it point back to itself via next and turn the list into a dead loop.

- In bt_sdp_unregister_service_mc():
  * After unlinking, clear service->next to NULL so the record becomes a clean, detached node that can be safely registered again.

