### PR TITLE
only send BT_HCI_ERR_AUTH_FAIL acl disconnect when l2cap     BT_L2CAP_BR_ERR_SEC_BLOCK.

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1101,7 +1101,9 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 
 no_chan:
 	l2cap_br_send_conn_rsp(conn, scid, 0, ident, result);
-	bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+	if (result == BT_L2CAP_BR_ERR_SEC_BLOCK) {
+		bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+	}
 }
 
 static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,


### PR DESCRIPTION
only send BT_HCI_ERR_AUTH_FAIL acl disconnect when l2cap
    BT_L2CAP_BR_ERR_SEC_BLOCK.
bug: v/79140

When a BR/EDR service requires encryption but the remote device attempts to open an L2CAP channel without first enabling encryption, the host returns a Security Block result. In Security Mode 4, the ACL link shall also be disconnected with the HCI Authentication Failure (0x05) reason.

I've check the test suite doc, that says:
<img width="897" height="761" alt="image" src="https://github.com/user-attachments/assets/180800ff-655e-4960-a29f-3f832bc4aadc" />


the table 4.14 shows result code: 0x0003
<img width="963" height="280" alt="image" src="https://github.com/user-attachments/assets/47e6730a-e9ea-4169-8bb0-fe2e6ad1c42f" />


0x0003 is security block not pending


So in the test diagram, "pending" seems to be a mistake in the document.

Based on this, we reply Security Block first, and then disconnect the ACL with Authentication Failure.
With this change, we were able to successfully pass the ALT2 test on our side.