### PR TITLE
fix BR/EDR L2CAP info response lost due to deferred connected callback

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -224,7 +224,7 @@ void bt_hci_synchronous_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 
 static void br_report_connection_state(struct bt_conn *conn)
 {
-	bt_conn_connected(conn);
+	bt_conn_notify_connected(conn);
 
 	if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND)) {
 		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING_CONN_PEND);
@@ -276,6 +276,8 @@ void bt_hci_conn_complete(struct bt_dev *hdev, struct net_buf *buf)
 	bt_conn_set_state(conn, BT_CONN_CONNECTED);
 
 	atomic_set_bit_to(conn->flags, BT_CONN_BR_BONDABLE, bt_get_bondable_mc(hdev->dev_id));
+
+	bt_conn_connected(conn);
 
 	buf = bt_hci_cmd_create(BT_HCI_OP_READ_REMOTE_FEATURES, sizeof(*cp));
 	if (!buf) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1863,11 +1863,26 @@ static void schedule_auto_initiated_procedures(struct bt_conn *conn)
 	k_work_submit(&hdev->conn_ctx->procedures_on_connect);
 }
 
+void bt_conn_notify_connected(struct bt_conn *conn)
+{
+	if (conn->type == BT_CONN_TYPE_BR) {
+		notify_connected(conn);
+	} else {
+		__ASSERT(false, "Only for BR/EDR, type %u", conn->type);
+	}
+}
+
 void bt_conn_connected(struct bt_conn *conn)
 {
 	schedule_auto_initiated_procedures(conn);
 	bt_l2cap_connected(conn);
-	notify_connected(conn);
+
+	/* BR/EDR notify is triggered via bt_conn_notify_connected(); notify LE here.
+	* TODO: Remove this split after BLE connected callback refactor unifies it.
+	*/
+	if (conn->type != BT_CONN_TYPE_BR) {
+		notify_connected(conn);
+	}
 }
 
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -558,6 +558,7 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 void bt_conn_notify_mode_changed(struct bt_conn *conn, uint8_t mode, uint16_t interval);
 #endif /* CONFIG_BT_POWER_MODE_CONTROL */
 
+void bt_conn_notify_connected(struct bt_conn *conn);
 void bt_conn_notify_role_changed(struct bt_conn *conn, uint8_t role);
 void bt_conn_notify_connect_req(struct bt_conn *conn, uint8_t link_type, uint8_t *cod);
 #endif /* CONFIG_BT_CLASSIC */


### PR DESCRIPTION
bug: v/79367

Root Cause:
https://github.com/open-vela/external_zblue/pull/125/ 

Previous PR #125 moved the bt_conn_connected() call (which triggers application connected callbacks) after reading remote features to ensure version info and features are available before notifying apps.

However, this caused an unintended side effect: the internal L2CAP module's connected callback was also deferred, preventing the L2CAP signaling channel from being properly initialized before the link-layer ACL connection was fully established. As a result, L2CAP Information Response packets from the remote device were dropped because the signaling channel did not exist yet.

Solution:
Separate internal stack callbacks from upper-layer application callbacks:
- Introduce bt_conn_notify_connected() to specifically trigger application-level connected callbacks
- Keep bt_conn_connected() for internal stack initialization (L2CAP signaling channel setup, auto-initiated procedures scheduling)
- Call bt_conn_connected() early (right after connection complete event) to ensure L2CAP signaling channel is ready
- Call bt_conn_notify_connected() later (after reading remote features) for BR/EDR connections to provide complete device info to applications

This ensures:
1. L2CAP signaling channel is initialized before any L2CAP packets arrive
2. Applications still receive connected callbacks with remote device info
3. LE connections remain unaffected (notify immediately as before)

Changes:
- conn.c: Split bt_conn_connected() and bt_conn_notify_connected()
- br.c: Call bt_conn_connected() early, bt_conn_notify_connected() late
- conn_internal.h: Add bt_conn_notify_connected() declaration