### PR TITLE
bluetooth: Fix the issue where AVRCP notifications are not functionin…

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -392,10 +392,7 @@ static inline struct bt_avrcp_ct *get_avrcp_ct(struct bt_avrcp *avrcp)
 {
 	size_t index;
 
-	if (avrcp == NULL) {
-		LOG_ERR("Invalid parameter");
-		return NULL;
-	}
+	__ASSERT(avrcp != NULL, "avrcp is NULL");
 
 	index = (size_t)bt_conn_index(avrcp->acl_conn);
 	__ASSERT(index < ARRAY_SIZE(avrcp_connection), "Conn index is out of bounds");
@@ -407,10 +404,7 @@ static inline struct bt_avrcp_tg *get_avrcp_tg(struct bt_avrcp *avrcp)
 {
 	size_t index;
 
-	if (avrcp == NULL) {
-		LOG_ERR("Invalid parameter");
-		return NULL;
-	}
+	__ASSERT(avrcp != NULL, "avrcp is NULL");
 
 	index = (size_t)bt_conn_index(avrcp->acl_conn);
 	__ASSERT(index < ARRAY_SIZE(avrcp_connection), "Conn index is out of bounds");

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -473,7 +473,9 @@ static void avrcp_disconnected(struct bt_avctp *session)
 	struct bt_avrcp *avrcp = AVRCP_AVCTP(session);
 
 	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->disconnected != NULL)) {
-		avrcp_ct_cb->disconnected(get_avrcp_ct(avrcp));
+		struct bt_avrcp_ct *ct = get_avrcp_ct(avrcp);
+		avrcp_ct_cb->disconnected(ct);
+		memset(&ct->ct_notify, 0, sizeof(ct->ct_notify));
 	}
 
 	if ((avrcp_tg_cb != NULL) && (avrcp_tg_cb->disconnected != NULL)) {


### PR DESCRIPTION
…g properly.

bug: v/80686

When calling bt_avrcp_ct_register_notification, it sets ct->ct_notify[event_id].cb = cb;. In process_register_notification_rsp, it clears the callback by setting ct->ct_notify[event_id].cb = NULL;. However, when the connection is disconnected, the callback ct->ct_notify[event_id].cb is not set to NULL , causing subsequent notification registrations to fail immediately with an error because the callback pointer is still active.


