### PR TITLE
logging: Adapt log interface to bluetooth framework

### DIFF
--- a/port/include/zephyr/logging/log.h
+++ b/port/include/zephyr/logging/log.h
@@ -52,6 +52,10 @@
 #define CONFIG_BT_L2CAP_LOG_LEVEL CONFIG_BT_DEBUG_LOG_LEVEL
 #endif
 
+#ifndef CONFIG_SETTINGS_LOG_LEVEL
+#define CONFIG_SETTINGS_LOG_LEVEL CONFIG_BT_DEBUG_LOG_LEVEL
+#endif
+
 struct port_log_module_data {
     const char *name;
     int level;
@@ -104,7 +108,7 @@ static struct port_log_module_data *__log_module __attribute__((used)) = &__log_
 
 #define LOG_MODULE_REGISTER(...) _LOG_MODULE_REGISTER_N(_NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
 
-#define LOG_MODULE_DECLARE(...) LOG_MODULE_REGISTER(...)
+#define LOG_MODULE_DECLARE(...) LOG_MODULE_REGISTER(__VA_ARGS__)
 
 /* Core logging implementation: forward messages to syslog() when enabled
  * by both the global Bluetooth log level and the per-module log level.

--- a/port/include/zephyr/logging/log.h
+++ b/port/include/zephyr/logging/log.h
@@ -9,66 +9,118 @@
 
 #include <nuttx/config.h>
 #include <syslog.h>
+#include <stdio.h>
+#include <stdbool.h>
 
-#define LOG_MODULE_REGISTER(...)
+/* Basic helper macros */
+#define _LOG_CONCAT(x, y) x ## y
+#define LOG_CONCAT(x, y)  _LOG_CONCAT(x, y)
+
+#define _GET_ARG_N(_1, _2, _3, _4, _5, N, ...)  N
+#define _NUM_ARGS(...) _GET_ARG_N(__VA_ARGS__, 5, 4, 3, 2, 1, 0)
+
+/* Log level mapping (syslog-compatible). */
+#define PORT_LOG_EMERG   0
+#define PORT_LOG_ALERT   1
+#define PORT_LOG_CRIT    2
+#define PORT_LOG_ERR     3
+#define PORT_LOG_WARNING 4
+#define PORT_LOG_NOTICE  5
+#define PORT_LOG_INFO    6
+#define PORT_LOG_DEBUG   7
+
+/* Zephyr-like aliases (optional) */
+#define LOG_LEVEL_NONE PORT_LOG_EMERG
+#define LOG_LEVEL_ERR  PORT_LOG_ERR
+#define LOG_LEVEL_WRN  PORT_LOG_WARNING
+#define LOG_LEVEL_INF  PORT_LOG_INFO
+#define LOG_LEVEL_DBG  PORT_LOG_DEBUG
+
+#ifndef CONFIG_BT_DEBUG_LOG_LEVEL
+#define CONFIG_BT_DEBUG_LOG_LEVEL LOG_LEVEL_INF
+#endif
+
+#ifndef CONFIG_BT_LOG_LEVEL
+#define CONFIG_BT_LOG_LEVEL CONFIG_BT_DEBUG_LOG_LEVEL
+#endif
+
+#ifndef CONFIG_NET_BUF_LOG_LEVEL
+#define CONFIG_NET_BUF_LOG_LEVEL CONFIG_BT_DEBUG_LOG_LEVEL
+#endif
+
+#ifndef CONFIG_BT_L2CAP_LOG_LEVEL
+#define CONFIG_BT_L2CAP_LOG_LEVEL CONFIG_BT_DEBUG_LOG_LEVEL
+#endif
+
+struct port_log_module_data {
+    const char *name;
+    int level;
+};
+
+/* Default log module data (implemented in log.c). */
+extern const struct port_log_module_data __log_default_data;
+
+/* Each translation unit that includes this header and does not call
+ * LOG_MODULE_REGISTER() will use this default module data.
+ */
+static const struct port_log_module_data *__log_module = &__log_default_data;
+
+/* Registration macros: set up per-module log data and update __log_module
+ * at runtime using constructor functions.
+ */
+#define _LOG_MODULE_REGISTER_1(module_name) \
+    static const struct port_log_module_data __log_data_##module_name = { \
+        .name = #module_name, \
+        .level = CONFIG_BT_DEBUG_LOG_LEVEL, \
+    }; \
+    static void __attribute__((constructor)) __log_init_##module_name(void) { \
+        __log_module = &__log_data_##module_name; \
+    }
+
+#define _LOG_MODULE_REGISTER_2(module_name, _level) \
+    static const struct port_log_module_data __log_data_##module_name = { \
+        .name = #module_name, \
+        .level = _level, \
+    }; \
+    static void __attribute__((constructor)) __log_init_##module_name(void) { \
+        __log_module = &__log_data_##module_name; \
+    }
+
+#define _LOG_MODULE_REGISTER_N(N, ...) LOG_CONCAT(_LOG_MODULE_REGISTER_, N)(__VA_ARGS__)
+
+#define LOG_MODULE_REGISTER(...) \
+    _LOG_MODULE_REGISTER_N(_NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
+
 #define LOG_MODULE_DECLARE(...)
 
+/* Core logging implementation: forward messages to syslog() when enabled
+ * by both the global Bluetooth log level and the per-module log level.
+ */
+#define PORT_LOG(_level, lvl_str, fmt, ...) do { \
+    if (_level <= CONFIG_BT_LOG_LEVEL) { \
+        if (_level <= __log_module->level) { \
+            syslog(_level, "[%s] %s " fmt "\n", \
+                    __log_module->name, \
+                    lvl_str, \
+                    ##__VA_ARGS__); \
+        } \
+    } \
+} while(0)
+
+/* Public logging macros. Undefine potential definitions from syslog.h
+ * before providing the Zephyr-style APIs.
+ */
 #undef LOG_DBG
 #undef LOG_INF
 #undef LOG_WRN
 #undef LOG_ERR
 
-/*
- * Conflict Log Tags from NuttX definition.
- * These defines follow the values used by syslog(2)
- */
+#define LOG_ERR(fmt, ...) PORT_LOG(LOG_LEVEL_ERR, "<err>", fmt, ##__VA_ARGS__)
+#define LOG_WRN(fmt, ...) PORT_LOG(LOG_LEVEL_WRN, "<wrn>", fmt, ##__VA_ARGS__)
+#define LOG_INF(fmt, ...) PORT_LOG(LOG_LEVEL_INF, "<inf>", fmt, ##__VA_ARGS__)
+#define LOG_DBG(fmt, ...) PORT_LOG(LOG_LEVEL_DBG, "<dbg>", fmt, ##__VA_ARGS__)
 
-#define PORT_LOG_EMERG     0  /* System is unusable */
-#define PORT_LOG_ALERT     1  /* Action must be taken immediately */
-#define PORT_LOG_CRIT      2  /* Critical conditions */
-#define PORT_LOG_ERR       3  /* Error conditions */
-#define PORT_LOG_WARNING   4  /* Warning conditions */
-#define PORT_LOG_NOTICE    5  /* Normal, but significant, condition */
-#define PORT_LOG_INFO      6  /* Informational message */
-#define PORT_LOG_DEBUG     7  /* Debug-level message */
-
-#define PORT_LOG(_level, _l_str, fmt, args...) do { \
-    char _log_buf[64]; \
-    int _pos = 0; \
-    _pos += snprintf(_log_buf + _pos, sizeof(_log_buf) - _pos, _l_str); \
-    if (IS_ENABLED(CONFIG_BT_DEBUG_LOG_FUNCTION_NAME)) { \
-        _pos += snprintf(_log_buf + _pos, sizeof(_log_buf) - _pos, " [%s]", __func__); \
-    } \
-    if (IS_ENABLED(CONFIG_BT_DEBUG_LOG_LINE_NUMBER)) { \
-        _pos += snprintf(_log_buf + _pos, sizeof(_log_buf) - _pos, " <%d>:", __LINE__); \
-    } \
-    syslog(_level, "%s " fmt "\n", _log_buf, ##args); \
-} while (0)
-
-#if (CONFIG_BT_DEBUG_LOG_LEVEL >= PORT_LOG_DEBUG)
-  #define LOG_DBG(fmt, ...) PORT_LOG(PORT_LOG_DEBUG, "<dbg>", fmt, ##__VA_ARGS__)
-#else
-  #define LOG_DBG(fmt, ...)
-#endif
-
-#if (CONFIG_BT_DEBUG_LOG_LEVEL >= PORT_LOG_INFO)
-  #define LOG_INF(fmt, ...) PORT_LOG(PORT_LOG_INFO, "<inf>", fmt, ##__VA_ARGS__)
-#else
-  #define LOG_INF(fmt, ...)
-#endif
-
-#if (CONFIG_BT_DEBUG_LOG_LEVEL >= PORT_LOG_WARNING)
-  #define LOG_WRN(fmt, ...) PORT_LOG(PORT_LOG_WARNING, "<wrn>", fmt, ##__VA_ARGS__)
-#else
-  #define LOG_WRN(fmt, ...)
-#endif
-
-#if (CONFIG_BT_DEBUG_LOG_LEVEL >= PORT_LOG_ERR)
-  #define LOG_ERR(fmt, ...) PORT_LOG(PORT_LOG_ERR, "<err>", fmt, ##__VA_ARGS__)
-#else
-  #define LOG_ERR(fmt, ...)
-#endif
-
+/* Hexdump logging helpers: currently implemented as no-ops. */
 #define LOG_HEXDUMP_INF(_data, _length, _str)
 #define LOG_HEXDUMP_DBG(_data, _length, _str)
 

--- a/port/include/zephyr/logging/log.h
+++ b/port/include/zephyr/logging/log.h
@@ -55,54 +55,67 @@
 struct port_log_module_data {
     const char *name;
     int level;
+    struct port_log_module_data *next;
 };
 
+void port_log_default_module_init(void);
+void port_log_module_list_add(struct port_log_module_data *module);
+void port_log_module_set_level(const char *module_name, int level);
+int port_log_module_get_level(const char *module_name);
+
+void port_log_output_enable(void);
+void port_log_output_disable(void);
+bool port_log_output_is_enabled(void);
+
 /* Default log module data (implemented in log.c). */
-extern const struct port_log_module_data __log_default_data;
+extern struct port_log_module_data __log_default_data;
 
 /* Each translation unit that includes this header and does not call
  * LOG_MODULE_REGISTER() will use this default module data.
  */
-static const struct port_log_module_data *__log_module = &__log_default_data;
+static struct port_log_module_data *__log_module __attribute__((used)) = &__log_default_data;
 
 /* Registration macros: set up per-module log data and update __log_module
  * at runtime using constructor functions.
  */
 #define _LOG_MODULE_REGISTER_1(module_name) \
-    static const struct port_log_module_data __log_data_##module_name = { \
+    static struct port_log_module_data __log_data_##module_name = { \
         .name = #module_name, \
         .level = CONFIG_BT_DEBUG_LOG_LEVEL, \
+        .next = NULL, \
     }; \
     static void __attribute__((constructor)) __log_init_##module_name(void) { \
         __log_module = &__log_data_##module_name; \
+        port_log_module_list_add(&__log_data_##module_name); \
     }
 
 #define _LOG_MODULE_REGISTER_2(module_name, _level) \
-    static const struct port_log_module_data __log_data_##module_name = { \
+    static struct port_log_module_data __log_data_##module_name = { \
         .name = #module_name, \
         .level = _level, \
+        .next = NULL, \
     }; \
     static void __attribute__((constructor)) __log_init_##module_name(void) { \
         __log_module = &__log_data_##module_name; \
+        port_log_module_list_add(&__log_data_##module_name); \
     }
 
 #define _LOG_MODULE_REGISTER_N(N, ...) LOG_CONCAT(_LOG_MODULE_REGISTER_, N)(__VA_ARGS__)
 
-#define LOG_MODULE_REGISTER(...) \
-    _LOG_MODULE_REGISTER_N(_NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
+#define LOG_MODULE_REGISTER(...) _LOG_MODULE_REGISTER_N(_NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
 
-#define LOG_MODULE_DECLARE(...)
+#define LOG_MODULE_DECLARE(...) LOG_MODULE_REGISTER(...)
 
 /* Core logging implementation: forward messages to syslog() when enabled
  * by both the global Bluetooth log level and the per-module log level.
  */
 #define PORT_LOG(_level, lvl_str, fmt, ...) do { \
-    if (_level <= CONFIG_BT_LOG_LEVEL) { \
+    if (port_log_output_is_enabled() && (_level <= CONFIG_BT_LOG_LEVEL)) { \
         if (_level <= __log_module->level) { \
             syslog(_level, "[%s] %s " fmt "\n", \
-                    __log_module->name, \
-                    lvl_str, \
-                    ##__VA_ARGS__); \
+                   __log_module->name, \
+                   lvl_str, \
+                   ##__VA_ARGS__); \
         } \
     } \
 } while(0)

--- a/port/subsys/logging/log.c
+++ b/port/subsys/logging/log.c
@@ -1,0 +1,9 @@
+#include <zephyr/logging/log.h>
+
+/* Default log module used when a translation unit does not register its
+ * own module via LOG_MODULE_REGISTER().
+ */
+const struct port_log_module_data __log_default_data = {
+    .name = "sys",
+    .level = LOG_LEVEL_INF
+};

--- a/port/subsys/logging/log.c
+++ b/port/subsys/logging/log.c
@@ -1,9 +1,72 @@
-#include <zephyr/logging/log.h>
-
-/* Default log module used when a translation unit does not register its
- * own module via LOG_MODULE_REGISTER().
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
-const struct port_log_module_data __log_default_data = {
-    .name = "sys",
-    .level = LOG_LEVEL_INF
+
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+static struct port_log_module_data *g_log_modules_list = NULL;
+static bool g_log_output_enabled = false;
+
+/* Default module data: used if a translation unit does not register its
+ * own module.
+ */
+struct port_log_module_data __log_default_data = {
+    .name = "default",
+    .level = CONFIG_BT_DEBUG_LOG_LEVEL,
+    .next = NULL,
 };
+
+void port_log_module_list_add(struct port_log_module_data *module)
+{
+    if (module) {
+        module->next = g_log_modules_list;
+        g_log_modules_list = module;
+    }
+}
+
+void port_log_module_set_level(const char *module_name, int level)
+{
+    struct port_log_module_data *current = g_log_modules_list;
+    while (current) {
+        if (strcmp(current->name, module_name) == 0) {
+            current->level = level;
+            return;
+        }
+        current = current->next;
+    }
+}
+
+int port_log_module_get_level(const char *module_name)
+{
+    struct port_log_module_data *current = g_log_modules_list;
+    while (current) {
+        if (strcmp(current->name, module_name) == 0) {
+            return current->level;
+        }
+        current = current->next;
+    }
+
+    if (strcmp(__log_default_data.name, module_name) == 0) {
+        return __log_default_data.level;
+    }
+
+    return -1; /* Not found */
+}
+
+void port_log_output_enable(void)
+{
+    g_log_output_enabled = true;
+}
+
+void port_log_output_disable(void)
+{
+    g_log_output_enabled = false;
+}
+
+bool port_log_output_is_enabled(void)
+{
+    return g_log_output_enabled;
+}


### PR DESCRIPTION
logging: Adapt log interface to bluetooth framework

bug: v/81365

Refactored the logging system to support Zephyr-style module-based logging for the Bluetooth framework. Added LOG_MODULE_REGISTER() macro with per-module log level control, implemented module data structure and registration mechanism using constructor functions. Replaced compile-time log level checks with runtime filtering based on both global and per-module log levels. Added global log output control to enable or disable all logging at runtime. Added default log module implementation in log.c. The logging macros (LOG_ERR, LOG_WRN, LOG_INF, LOG_DBG) now filter messages at runtime.

