### PR TITLE
zblue: port: Fix hang after sending many AG vendor commands

### DIFF
--- a/port/kernel/poll.c
+++ b/port/kernel/poll.c
@@ -275,6 +275,8 @@ int k_poll(struct k_poll_event *events, int num_events,
 		return -EAGAIN;
 	}
 
+	k_spin_unlock(&lock, key);
+
 	int ret = k_sem_take(&poller.sem, timeout);
 
 	/*


### PR DESCRIPTION
bug: v/82282

Rootcause: function k_poll locks spinlock twice but only unlocks once


