### PR TITLE
avrcp: Fix missing variable reset in ct registration notification err…

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -3228,9 +3228,6 @@ int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8
 	if (ct->ct_notify[event_id].cb != NULL) {
 		return -EBUSY;
 	}
-	ct->ct_notify[event_id].cb = cb;
-	ct->ct_notify[event_id].interim_received = 0;
-	ct->ct_notify[event_id].tid = tid;
 
 	buf = avrcp_prepare_vendor_pdu(ct->avrcp, BT_AVRCP_PKT_TYPE_SINGLE, BT_AVRCP_CTYPE_NOTIFY,
 				       BT_AVRCP_PDU_ID_REGISTER_NOTIFICATION, param_len);
@@ -3243,14 +3240,18 @@ int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8
 	/* Add playback interval */
 	net_buf_add_be32(buf, interval);
 
-	err = avrcp_send(ct->avrcp, buf, BT_AVCTP_CMD, ct->ct_notify[event_id].tid);
+	err = avrcp_send(ct->avrcp, buf, BT_AVCTP_CMD, tid);
 	if (err < 0) {
 		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
 		net_buf_unref(buf);
 		/* Roll back state so the app can retry */
-		ct->ct_notify[event_id].cb = NULL;
-		ct->ct_notify[event_id].interim_received = 0;
+		return err;
 	}
+
+	ct->ct_notify[event_id].cb = cb;
+	ct->ct_notify[event_id].interim_received = 0;
+	ct->ct_notify[event_id].tid = tid;
+
 	return err;
 }
 

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -3244,7 +3244,6 @@ int bt_avrcp_ct_register_notification(struct bt_avrcp_ct *ct, uint8_t tid, uint8
 	if (err < 0) {
 		LOG_ERR("Failed to send AVRCP PDU (err: %d)", err);
 		net_buf_unref(buf);
-		/* Roll back state so the app can retry */
 		return err;
 	}
 


### PR DESCRIPTION
…ors.

bug: v/81517

Failure to clear ct->ct_notify[event_id] when avrcp_prepare_vendor_pdu fails, leading to an error return if ct->ct_notify[event_id].cb != NULL during the next notification registration.

