### PR TITLE
Supports app confirmation during Just Work pairing in the app.

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -548,6 +548,12 @@ config BT_SMP_APP_PAIRING_ACCEPT
 	  The application can return an error code, which is translated into
 	  a SMP return value if the pairing is not allowed.
 
+config HCI_AUTO_REPLY_IN_JUST_WORK
+	bool "SSP auto reply in just work"
+	default y
+	help
+	  SSP auto reply in just work
+
 config BT_SMP_SC_PAIR_ONLY
 	bool "Disable legacy pairing"
 	help

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -285,6 +285,7 @@ static void ssp_auth(struct bt_conn *conn, uint32_t passkey)
 		 * model is applied then notify user about such pairing request.
 		 * [BT Core 4.2 table 5.7, Vol 3, Part C, 5.2.2.6]
 		 */
+#ifdef CONFIG_HCI_AUTO_REPLY_IN_JUST_WORK
 		if (conn->hdev->bt_auth && conn->hdev->bt_auth->pairing_confirm &&
 		    !atomic_test_bit(conn->flags,
 				     BT_CONN_BR_PAIRING_INITIATOR)) {
@@ -292,6 +293,13 @@ static void ssp_auth(struct bt_conn *conn, uint32_t passkey)
 			conn->hdev->bt_auth->pairing_confirm(conn);
 			break;
 		}
+#else
+		if (conn->hdev->bt_auth && conn->hdev->bt_auth->passkey_confirm) {
+			atomic_set_bit(conn->flags, BT_CONN_USER);
+			conn->hdev->bt_auth->passkey_confirm(conn, 0xFFFFFFFF);
+			break;
+		}
+#endif
 		ssp_confirm_reply(conn);
 		break;
 	default:


### PR DESCRIPTION
bug: v/81924

By default, just working (no I/O) should automatically accept user confirmation, but for compatibility with the watch app, app confirmation is required.