### PR TITLE
BT_GATT_AUTO_RESUBSCRIBE set to default n

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -70,7 +70,7 @@ endif # BT_EATT
 
 config BT_GATT_AUTO_RESUBSCRIBE
 	bool "Automatic re-subscription to characteristics"
-	default y
+	default n
 	imply BT_GATT_AUTO_SEC_REQ
 	depends on BT_GATT_CLIENT
 	help


### PR DESCRIPTION
bug: v/83028

when reconnection, app will do gatt client discovery and subscribe again, no need stack do it.

