### PR TITLE
bluetooth: classic: Fix remote name resolving with multiple devices

### DIFF
--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -48,7 +48,7 @@ struct bt_br_discovery_priv {
 	/** Page scan repetition mode */
 	uint8_t pscan_rep_mode;
 	/** Resolving remote name*/
-	bool resolving;
+	uint8_t resolve_state;
 };
 
 /** @brief BR/EDR discovery result structure */

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -22,6 +22,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_br);
 
+enum __packed resolve_name_state {
+	RESOLVE_REMOTE_NAME_PENDING,
+	RESOLVE_REMOTE_NAME_RESOLVING,
+	RESOLVE_REMOTE_NAME_RESOLVED,
+};
+
 int bt_reject_conn(struct bt_dev *hdev, const bt_addr_t *bdaddr, uint8_t reason)
 {
 	struct bt_hci_cp_reject_conn_req *cp;
@@ -363,11 +369,19 @@ void bt_br_discovery_reset(struct bt_dev *hdev)
 	hdev->discovery_results_count = 0;
 }
 
-static void report_discovery_results(struct bt_dev *hdev)
+void bt_br_discovery_clear_callbacks(struct bt_dev *hdev)
 {
-	bool resolving_names = false;
+	if (!hdev) {
+		return;
+	}
+
+	sys_slist_init(&hdev->discovery_cbs);
+}
+
+static bool check_request_name(struct bt_dev *hdev)
+{
 	int i;
-	struct bt_br_discovery_cb *listener, *next;
+	bool resolving_names = false;
 
 	for (i = 0; i < hdev->discovery_results_count; i++) {
 		struct bt_br_discovery_priv *priv;
@@ -378,16 +392,37 @@ static void report_discovery_results(struct bt_dev *hdev)
 			continue;
 		}
 
-		if (request_name(hdev, &hdev->discovery_results[i].addr, priv->pscan_rep_mode,
-				 priv->clock_offset)) {
+		if (priv->resolve_state != RESOLVE_REMOTE_NAME_PENDING) {
 			continue;
 		}
 
-		priv->resolving = true;
+		if (request_name(hdev, &hdev->discovery_results[i].addr, priv->pscan_rep_mode,
+				 priv->clock_offset)) {
+			priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVED;
+			continue;
+		}
+
+		priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVING;
 		resolving_names = true;
+		break;
 	}
 
-	if (resolving_names) {
+	return resolving_names;
+}
+
+static void report_discovery_results(struct bt_dev *hdev)
+{
+	int i;
+	struct bt_br_discovery_cb *listener, *next;
+
+	for (i = 0; i < hdev->discovery_results_count; i++) {
+		struct bt_br_discovery_priv *priv;
+
+		priv = &hdev->discovery_results[i]._priv;
+		priv->resolve_state = RESOLVE_REMOTE_NAME_PENDING;
+	}
+
+	if (check_request_name(hdev)) {
 		return;
 	}
 
@@ -562,7 +597,6 @@ void bt_hci_remote_name_request_complete(struct bt_dev *hdev, struct net_buf *bu
 	struct bt_br_discovery_priv *priv;
 	int eir_len = 240;
 	uint8_t *eir;
-	int i;
 	struct bt_br_discovery_cb *listener, *next;
 
 	if (hdev->rnr_cb.cb && !bt_addr_cmp(&evt->bdaddr, &hdev->rnr_cb.addr)) {
@@ -577,7 +611,7 @@ void bt_hci_remote_name_request_complete(struct bt_dev *hdev, struct net_buf *bu
 	}
 
 	priv = &result->_priv;
-	priv->resolving = false;
+	priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVED;
 
 	if (evt->status) {
 		goto check_names;
@@ -629,15 +663,9 @@ void bt_hci_remote_name_request_complete(struct bt_dev *hdev, struct net_buf *bu
 	}
 
 check_names:
-	/* if still waiting for names */
-	for (i = 0; i < hdev->discovery_results_count; i++) {
-		struct bt_br_discovery_priv *dpriv;
-
-		dpriv = &hdev->discovery_results[i]._priv;
-
-		if (dpriv->resolving) {
-			return;
-		}
+	/* if still need to request name */
+	if (check_request_name(hdev)) {
+		return;
 	}
 
 	/* all names resolved, report discovery results */
@@ -1102,7 +1130,7 @@ int bt_br_discovery_stop_mc(uint8_t dev_id)
 
 		priv = &hdev->discovery_results[i]._priv;
 
-		if (!priv->resolving) {
+		if (priv->resolve_state != RESOLVE_REMOTE_NAME_RESOLVING) {
 			continue;
 		}
 
@@ -1515,14 +1543,21 @@ int bt_br_remote_name_request_mc(uint8_t dev_id, const bt_addr_t *bdaddr, bt_br_
 	/* check if we have a cached result */
 	result = find_discovery_result(hdev, bdaddr);
 	if (result) {
-		/* check is resolving, just return if resolving */
+        /* Already resolving or already resolved: no need to send again */
 		priv = (struct bt_br_discovery_priv *)&result->_priv;
-		if (priv->resolving) {
-			return 0;
+        if (priv->resolve_state == RESOLVE_REMOTE_NAME_RESOLVING ||
+            priv->resolve_state == RESOLVE_REMOTE_NAME_RESOLVED) {
+			memset(&hdev->rnr_cb, 0, sizeof(hdev->rnr_cb));
+            return 0;
+        }
+
+		priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVING;
+		err = request_name(hdev, bdaddr, priv->pscan_rep_mode, priv->clock_offset);
+
+		if (err) {
+			priv->resolve_state = RESOLVE_REMOTE_NAME_PENDING;
 		}
 
-		priv->resolving = 1;
-		err = request_name(hdev, bdaddr, priv->pscan_rep_mode, priv->clock_offset);
 	} else {
 		/* start discovery to resolve name by default param */
 		err = request_name(hdev, bdaddr, BT_HCI_PAGE_SCAN_REP_MODE_R2, 0);


### PR DESCRIPTION
bug: v/83998

The error occur when discoverying br devices and need to send request_name for many found devices.
In system work queue task, bt_hci_inquiry_complete-> report_discovery_results is called, then request_name is called for all the found devices. The controller gives HCI_Remote_Name_Request_Complete event for every name request result and one buf is allocated from hci_rx_pool to save HCI_Remote_Name_Request_Complete. When system work queue task is blocked to call request_name for every device, many HCI_Remote_Name_Request_Complete are received for the already sent request_name, it uses up all the buf of hci_rx_pool, then the bt_rx_thread task is blocked to get buf from hci_rx_pool when next HCI_Remote_Name_Request_Complete is received, meanwhile the next request_name send hci cmd and wait the result, but the hci status/complete event can't be received because the bt_rx_thread is blocked and bt_uart_isr is kept in the state to receive last
HCI_Remote_Name_Request_Complete, then bt_dev.ncmd_sem is not released, then the next request_name send hci cmd again, but the bt_dev.ncmd_sem is invalid, then bt_hci_cmd_send_sync fail and assert.

resolve it by requesting name one by one.


cherry-picks from https://github.com/zephyrproject-rtos/zephyr/pull/87666

