### PR TITLE
adapt legacy adv feature.

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1295,6 +1295,21 @@ struct bt_le_per_adv_param {
 						  BT_LE_PER_ADV_OPT_NONE)
 
 /**
+ * @brief Check whether LE extended advertising is supported.
+ *
+ * @param dev_id Bluetooth device/controller id.
+ *
+ * @return true if supported, false otherwise.
+ */
+bool bt_le_ext_adv_is_supported_mc(uint8_t dev_id);
+#ifdef CONFIG_BT_ORIGINAL_API
+static inline bool bt_le_ext_adv_is_supported(void)
+{
+	return bt_le_ext_adv_is_supported_mc(0);
+}
+#endif
+
+/**
  * @brief Start advertising
  *
  * Set advertisement data, scan response data, advertisement parameters

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -281,6 +281,7 @@ endif # BT_SETTINGS
 
 config BT_FILTER_ACCEPT_LIST
 	bool "Filter accept list support"
+	default y
 	help
 	  This option enables the filter accept list API. This takes advantage of the
 	  filtering feature of a BLE controller.

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1573,6 +1573,21 @@ void bt_le_adv_resume(struct bt_dev *hdev)
 }
 #endif /* defined(CONFIG_BT_PERIPHERAL) */
 
+bool bt_le_ext_adv_is_supported_mc(uint8_t dev_id)
+{
+	struct bt_dev *hdev = bt_dev_get(dev_id);
+
+	if (!hdev) {
+		return false;
+	}
+
+	if (!IS_ENABLED(CONFIG_BT_EXT_ADV)) {
+		return false;
+	}
+
+	return BT_DEV_FEAT_LE_EXT_ADV(hdev->le.features);
+}
+
 #if defined(CONFIG_BT_EXT_ADV)
 int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
 			   struct bt_le_ext_adv_info *info)


### PR DESCRIPTION
depends-on: [open-vela/frameworks_bluetooth/pull/389]

1. for app, such as adv filter, so open it
2. we need it to check controller support ext adv or not.