### PR TITLE
Fix the failed binding problem

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1585,7 +1585,7 @@ int bt_br_unpair_mc(uint8_t dev_id, bt_addr_t *bdaddr)
 	bt_keys_link_key_clear_addr(hdev, bdaddr);
 
 	/* Delete stored link key from controller */
-	bt_br_delete_stored_link_key(hdev, bdaddr, true);
+	bt_br_delete_stored_link_key(hdev, bdaddr, false);
 
 	addr.type = BT_ADDR_LE_PUBLIC;
 	memcpy(&addr, bdaddr, sizeof(addr));

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2844,7 +2844,7 @@ struct bt_conn *bt_conn_pair_br_mc(uint8_t dev_id, bt_addr_t *bdaddr, bt_securit
 	}
 
 	/* Tell controller to delete the link key if it has one stored */
-	bt_br_delete_stored_link_key(hdev, bdaddr, 0);
+	bt_br_delete_stored_link_key(hdev, bdaddr, false);
 
 	if (!BT_FEAT_SSP(hdev->features)) {
 		/* pin type */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2844,10 +2844,7 @@ struct bt_conn *bt_conn_pair_br_mc(uint8_t dev_id, bt_addr_t *bdaddr, bt_securit
 	}
 
 	/* Tell controller to delete the link key if it has one stored */
-	err = bt_br_delete_stored_link_key(hdev, bdaddr, 1);
-	if (err) {
-		return NULL;
-	}
+	bt_br_delete_stored_link_key(hdev, bdaddr, 0);
 
 	if (!BT_FEAT_SSP(hdev->features)) {
 		/* pin type */


### PR DESCRIPTION
bug: v/84588

Before pairing, the link key will be deleted. If the controller returns an error, subsequent connection processes will not proceed, leading to a bonding failure.

