### PR TITLE
Bluetooth: Core: add Mode Change event in event mask

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3975,6 +3975,7 @@ struct bt_hci_evt_le_cs_procedure_enable_complete {
 #define BT_EVT_MASK_REMOTE_VERSION_INFO          BT_EVT_BIT(11)
 #define BT_EVT_MASK_HARDWARE_ERROR               BT_EVT_BIT(15)
 #define BT_EVT_MASK_ROLE_CHANGE                  BT_EVT_BIT(17)
+#define BT_EVT_MASK_MODE_CHANGE                  BT_EVT_BIT(19)
 #define BT_EVT_MASK_PIN_CODE_REQ                 BT_EVT_BIT(21)
 #define BT_EVT_MASK_LINK_KEY_REQ                 BT_EVT_BIT(22)
 #define BT_EVT_MASK_LINK_KEY_NOTIFY              BT_EVT_BIT(23)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3864,6 +3864,9 @@ static int set_event_mask(struct bt_dev *hdev)
 		mask |= BT_EVT_MASK_REMOTE_NAME_REQ_COMPLETE;
 		mask |= BT_EVT_MASK_REMOTE_FEATURES;
 		mask |= BT_EVT_MASK_ROLE_CHANGE;
+#ifdef CONFIG_BT_POWER_MODE_CONTROL
+		mask |= BT_EVT_MASK_MODE_CHANGE;
+#endif /* CONFIG_BT_POWER_MODE_CONTROL */
 		mask |= BT_EVT_MASK_PIN_CODE_REQ;
 		mask |= BT_EVT_MASK_LINK_KEY_REQ;
 		mask |= BT_EVT_MASK_LINK_KEY_NOTIFY;


### PR DESCRIPTION
bug: v/81937

Since we have already supported sniff mode,
the corresponding link mode change event should be received.