### PR TITLE
Bluetooth: Classic: L2CAP: fix NULL pointer crash in chan->ops->xx()

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2044,6 +2044,11 @@ void l2cap_br_encrypt_change(struct bt_conn *conn, uint8_t hci_status)
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn->channels, chan, node) {
 		l2cap_br_conn_pend(chan, hci_status);
 
+		if (chan->conn == NULL) {
+			LOG_WRN("Invalid ACL conn for chan %p", chan);
+			continue;
+		}
+
 		if (chan->ops && chan->ops->encrypt_change) {
 			chan->ops->encrypt_change(chan, hci_status);
 		}


### PR DESCRIPTION
bug: v/85078

for example:
l2cap_br_encrypt_change() calls l2cap_br_conn_pend(chan, hci_status) first, which may trigger l2cap_br_chan_cleanup(chan). This clears chan->conn and makes the channel invalid. The subsequent callback to chan->ops->encrypt_change(chan, hci_status) then dereferences a NULL conn in rfcomm_encrypt_change, causing a crash.