### PR TITLE
support normal inquiry result

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -3965,6 +3965,7 @@ struct bt_hci_evt_le_cs_procedure_enable_complete {
 #define BT_EVT_BIT(n) (1ULL << (n))
 
 #define BT_EVT_MASK_INQUIRY_COMPLETE             BT_EVT_BIT(0)
+#define BT_EVT_MASK_INQUIRY_RESULT               BT_EVT_BIT(1)
 #define BT_EVT_MASK_CONN_COMPLETE                BT_EVT_BIT(2)
 #define BT_EVT_MASK_CONN_REQUEST                 BT_EVT_BIT(3)
 #define BT_EVT_MASK_DISCONN_COMPLETE             BT_EVT_BIT(4)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3858,6 +3858,7 @@ static int set_event_mask(struct bt_dev *hdev)
 		 * Bluetooth 4.0 feature set
 		 */
 		mask |= BT_EVT_MASK_INQUIRY_COMPLETE;
+		mask |= BT_EVT_MASK_INQUIRY_RESULT;
 		mask |= BT_EVT_MASK_CONN_COMPLETE;
 		mask |= BT_EVT_MASK_CONN_REQUEST;
 		mask |= BT_EVT_MASK_AUTH_COMPLETE;


### PR DESCRIPTION
bug: v/84670

some dongle report inquiry result in legacy way, and we need receive it.