### PR TITLE
a2dp: Fix the issue where the A2DP stream fails to start.

### DIFF
--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -146,6 +146,8 @@ struct bt_avdtp_sep {
 	struct bt_avdtp *session;
 	/** endpoint becomes idle */
 	int (*endpoint_released)(struct bt_avdtp_sep *sep);
+	/** endpoint becomes ready */
+	int (*endpoint_established)(struct bt_avdtp_sep *sep);
 	/** delay worker for disconnecting l2cap media channel */
 	struct k_work_delayable _delay_work;
 	/** delay_work_state */

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -476,13 +476,11 @@ static int a2dp_open_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uin
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_ctrl_req_cb req_cb;
-	bt_a2dp_ctrl_done_cb done_cb;
 
 	__ASSERT(sep, "Invalid sep");
 	req_cb = a2dp_cb != NULL ? a2dp_cb->establish_req : NULL;
-	done_cb = (ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->established
-								  : NULL;
-	return a2dp_ctrl_ind(session, sep, errcode, req_cb, done_cb);
+
+	return a2dp_ctrl_ind(session, sep, errcode, req_cb, NULL);
 }
 
 static int a2dp_start_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
@@ -1021,11 +1019,8 @@ static int bt_a2dp_open_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 {
 	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
 	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->establish_rsp : NULL;
-	bt_a2dp_done_cb done_cb = (ep->stream != NULL && ep->stream->ops != NULL)
-					  ? ep->stream->ops->established
-					  : NULL;
 
-	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb);
+	return bt_a2dp_ctrl_cb(req, rsp_cb, NULL);
 }
 
 static int bt_a2dp_start_cb(struct bt_avdtp_req *req, struct net_buf *buf)
@@ -1417,6 +1412,27 @@ int a2dp_endpoint_released(struct bt_avdtp_sep *sep)
 	return 0;
 }
 
+int a2dp_endpoint_established(struct bt_avdtp_sep *sep)
+{
+	struct bt_a2dp_ep *ep;
+
+	__ASSERT(sep, "Invalid sep");
+	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
+
+	if (ep->stream != NULL) {
+		struct bt_a2dp_stream_ops *ops;
+		struct bt_a2dp_stream *stream = ep->stream;
+
+		ops = stream->ops;
+
+		if ((ops != NULL) && (ops->established != NULL)) {
+			ops->established(stream);
+		}
+	}
+
+	return 0;
+}
+
 static const struct bt_avdtp_ops_cb signaling_avdtp_ops = {
 	.connected = a2dp_connected,
 	.disconnected = a2dp_disconnected,
@@ -1523,6 +1539,7 @@ int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t sep_t
 #endif
 
 	ep->sep.endpoint_released = a2dp_endpoint_released;
+	ep->sep.endpoint_established = a2dp_endpoint_established;
 	err = bt_avdtp_register_sep(media_type, sep_type, &(ep->sep));
 	if (err < 0) {
 		return err;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -269,15 +269,8 @@ void bt_avdtp_media_l2cap_connected(struct bt_l2cap_chan *chan)
 	LOG_DBG("chan %p session %p", chan, session);
 	bt_avdtp_set_state_lock(sep, AVDTP_OPEN);
 
-	if (session->req != NULL) {
-		struct bt_avdtp_req *req = session->req;
-
-		req->status = BT_AVDTP_SUCCESS;
-		bt_avdtp_clear_req(session);
-
-		if (req->func != NULL) {
-			req->func(req, NULL);
-		}
+	if (sep->endpoint_established != NULL) {
+		sep->endpoint_established(sep);
 	}
 }
 
@@ -1121,22 +1114,24 @@ static void avdtp_open_rsp(struct bt_avdtp *session, struct net_buf *buf, uint8_
 	k_work_cancel_delayable(&session->timeout_work);
 	avdtp_set_status(req, buf, msg_type);
 
-	if (req->status == BT_AVDTP_SUCCESS) {
-		bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPENING);
-
-		/* wait the media l2cap is established */
-		if (!avdtp_media_connect(session, CTRL_REQ(req)->sep)) {
-			return;
-		}
+	if (req->func != NULL) {
+		req->func(req, NULL);
 	}
 
 	if (req->status != BT_AVDTP_SUCCESS) {
 		bt_avdtp_clear_req(session);
-
-		if (req->func != NULL) {
-			req->func(req, NULL);
-		}
+		return;
 	}
+
+	bt_avdtp_set_state_lock(CTRL_REQ(req)->sep, AVDTP_OPENING);
+
+	/* wait the media l2cap is established */
+	int err = avdtp_media_connect(session, CTRL_REQ(req)->sep);
+	if (err) {
+		LOG_ERR("Media channel establishment failed.");
+	}
+
+	bt_avdtp_clear_req(session);
 }
 
 static void avdtp_handle_reject_with_acp_seid(struct net_buf *buf, struct bt_avdtp_req *req)


### PR DESCRIPTION
bug: v/85239

After a successful AVDTP open , the system immediately notifies the SAL (Service Access Layer)  that A2DP is established . The SAL then informs the service, which transitions to the 'open' state and attempts to send a START  command. However, the A2DP media channel  has not been fully established yet, leading to a 'start stream' failure . Solution : Only notify the SAL that A2DP is established after the A2DP media channel is successfully created .
