### PR TITLE
rfcomm: add debug logs for connection parameters

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -463,13 +463,16 @@ static void rfcomm_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
 
-	LOG_DBG("Session %p", session);
-
 	/* Need to include UIH header and FCS*/
 	session->mtu = MIN(session->br_chan.rx.mtu,
 			   session->br_chan.tx.mtu) -
 			   BT_RFCOMM_HDR_SIZE - BT_RFCOMM_FCS_SIZE;
 
+	LOG_INF("Session %p mtu %u chan %p rx mtu %u tx mtu %u",
+		session, session->mtu,
+		&session->br_chan.chan,
+		session->br_chan.rx.mtu,
+		session->br_chan.tx.mtu);
 	if (session->state == BT_RFCOMM_STATE_CONNECTING) {
 		rfcomm_send_sabm(session, 0);
 	}
@@ -912,6 +915,8 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 	k_fifo_init(&dlc->tx_queue);
 	k_work_init(&dlc->tx_work, rfcomm_dlc_tx_worker);
 
+	LOG_INF("session %p dlc %p dlci %u mtu %u initial credits %u",
+		dlc->session, dlc, dlc->dlci, dlc->mtu, dlc->rx_credit);
 	if (dlc->ops && dlc->ops->connected) {
 		dlc->ops->connected(dlc);
 	}
@@ -1077,6 +1082,8 @@ static int rfcomm_send_pn(struct bt_rfcomm_dlc *dlc, uint8_t cr)
 
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
+	LOG_DBG("session %p dlc %p dlci %u mtu %u credits %u",
+		dlc->session, dlc, pn->dlci, dlc->mtu, pn->credits);
 
 	return rfcomm_send(dlc->session, buf);
 }
@@ -1312,6 +1319,8 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 	struct bt_rfcomm_pn *pn = (void *)buf->data;
 	struct bt_rfcomm_dlc *dlc;
 
+	LOG_DBG("Session %p dlci %d mtu %d credits %d",
+		session, pn->dlci, sys_le16_to_cpu(pn->mtu), pn->credits);
 	dlc = rfcomm_dlcs_lookup_dlci(session->dlcs, pn->dlci);
 	if (!dlc) {
 		/*  Ignore if it is a response */
@@ -1753,6 +1762,9 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		k_work_init_delayable(&session->rtx_work,
 				      rfcomm_session_rtx_timeout);
 		k_sem_init(&session->fc, 0, 1);
+		LOG_DBG("session %p role %d chan %p rx mtu %d", session, role,
+			&session->br_chan.chan,
+			session->br_chan.rx.mtu);
 
 		return session;
 	}


### PR DESCRIPTION
bug: v/85535

Add LOG_DBG/LOG_INF statements to track:
- Session MTU and channel details after connection establishment
- DLC connection details with session context (dlci, mtu, initial credits)
- PN message parameters during send and receive (dlci, mtu, credits)

Upgrade critical connection logs to LOG_INF level for better visibility.