### PR TITLE
Bluetooth: Classic: HFP: Add APIs to get ACL connection from HFP AG/HF context

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -913,6 +913,16 @@ int Z_API(bt_hfp_ag_ongoing_calls)(struct bt_hfp_ag *ag, struct bt_hfp_ag_ongoin
  */
 int Z_API(bt_hfp_ag_send_vendor)(struct bt_hfp_ag *ag, const char *rsp);
 
+/** @brief Obtain the ACL connection corresponding to HFP AG.
+ *
+ *  @param ag HFP AG object.
+ *
+ *  @return Connection object associated with the HFP AG context. The caller gets a new
+ *  reference to the connection object which must be released with bt_conn_unref() once
+ *  done using the object.
+ */
+struct bt_conn *Z_API(bt_hfp_ag_get_conn)(struct bt_hfp_ag *ag);
+
 /** @brief Unregister HFP AG profile
  *
  *  Unregister the Handsfree AudioGateway profile callbacks previously registered with

--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -600,6 +600,16 @@ int Z_API(bt_hfp_hf_register)(struct bt_hfp_hf_cb *cb);
  */
 int Z_API(bt_hfp_hf_unregister)(void);
 
+/** @brief Obtain the ACL connection corresponding to HFP HF.
+ *
+ *  @param hf HFP HF object.
+ *
+ *  @return Connection object associated with the HFP HF context. The caller gets a new
+ *  reference to the connection object which must be released with bt_conn_unref() once
+ *  done using the object.
+ */
+struct bt_conn *Z_API(bt_hfp_hf_get_conn)(struct bt_hfp_hf *hf);
+
 /** @brief Initiate the service level connection establishment procedure
  *
  *  Initiate the service level connection establishment procedure on the

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -192,12 +192,14 @@ config BT_HFP_AG_EXT_ERR
 
 config BT_HFP_AG_CODEC_NEG
 	bool "Codec Negotiation for HFP AG [EXPERIMENTAL]"
+	default y
 	help
 	  This option enables Codec Negotiation for HFP AG
 
 if BT_HFP_AG_CODEC_NEG
 config BT_HFP_AG_CODEC_MSBC
 	bool "Support Codec mSBC for HFP AG [EXPERIMENTAL]"
+	default y
 	help
 	  This option enables Codec mSBC for HFP AG
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -5529,3 +5529,18 @@ failed:
 	bt_ag_send_ok_code(ag);
 	return err;
 }
+
+struct bt_conn *Z_API(bt_hfp_ag_get_conn)(struct bt_hfp_ag *ag)
+{
+	if (!ag) {
+		LOG_ERR("Invalid AG object");
+		return NULL;
+	}
+
+	if (!ag->acl_conn) {
+		LOG_ERR("Invalid ACL connection");
+		return NULL;
+	}
+
+	return bt_conn_ref(ag->acl_conn);
+}

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4585,3 +4585,18 @@ int Z_API(bt_hfp_hf_query_list_of_current_calls)(struct bt_hfp_hf *hf)
 
 	return err;
 }
+
+struct bt_conn *Z_API(bt_hfp_hf_get_conn)(struct bt_hfp_hf *hf)
+{
+	if (!hf) {
+		LOG_ERR("Invalid HF object");
+		return NULL;
+	}
+
+	if (!hf->acl) {
+		LOG_ERR("Invalid ACL connection");
+		return NULL;
+	}
+
+	return bt_conn_ref(hf->acl);
+}


### PR DESCRIPTION
depends-on: [ open-vela/frameworks_bluetooth/pull/395 ]

