### PR TITLE
Add flow control to the RX Bluetooth service to resolve data backlog in the protocol stack.

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -52,6 +52,14 @@ enum {
 
 struct bt_rfcomm_dlc;
 
+/** @brief RFCOMM RX credit update mode. */
+enum bt_rfcomm_rx_credit_mode {
+	/** Auto update credits after recv callback returns. */
+	BT_RFCOMM_RX_CREDIT_AUTO,
+	/** Application updates credits explicitly. */
+	BT_RFCOMM_RX_CREDIT_MANUAL,
+};
+
 /** @brief RFCOMM DLC operations structure. */
 struct bt_rfcomm_dlc_ops {
 	/** DLC connected callback
@@ -120,6 +128,7 @@ struct bt_rfcomm_dlc {
 	uint8_t                    dlci;
 	uint8_t                    state;
 	uint8_t                    rx_credit;
+	uint8_t                    rx_credit_mode;
 };
 
 struct bt_rfcomm_server {
@@ -239,6 +248,15 @@ int bt_rfcomm_server_register(struct bt_rfcomm_server *server);
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_rfcomm_server_unregister(struct bt_rfcomm_server *server);
+
+/** @brief Set RFCOMM RX credit update mode for a DLC.
+ *
+ *  @param dlc  The dlc to configure.
+ *  @param mode Credit update mode.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_rfcomm_dlc_set_rx_credit_mode(struct bt_rfcomm_dlc *dlc, enum bt_rfcomm_rx_credit_mode mode);
 
 /** @brief Connect RFCOMM channel
  *

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -278,6 +278,18 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
  */
 int bt_rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc);
 
+/** @brief Update RFCOMM RX credits after data is processed
+ *
+ *  Call this after the application has finished handling the data received in
+ *  the `recv` callback. This will update the RX credit accounting and sends
+ *  credits to the peer when needed.
+ *
+ *  @param dlc Dlc object.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc);
+
 /** @brief Allocate the buffer from pool after reserving head room for RFCOMM,
  *  L2CAP and ACL headers.
  *

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -1522,6 +1522,34 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 	rfcomm_send_credit(dlc, credits);
 }
 
+int bt_rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
+{
+
+	if (!dlc || !dlc->session) {
+		return -EINVAL;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_CONNECTED) {
+		LOG_WRN("dlc %p is not in connected state", dlc);
+		return -ENOTCONN;
+	}
+
+	if (dlc->session->cfc != BT_RFCOMM_CFC_SUPPORTED) {
+		LOG_WRN("dlc %p session does not support CFC", dlc);
+		return -ENOTSUP;
+	}
+
+	if (dlc->rx_credit == 0U) {
+		LOG_WRN("dlc %p rx credit already 0", dlc);
+		return -EAGAIN;
+	}
+
+	dlc->rx_credit--;
+	rfcomm_dlc_update_credits(dlc);
+
+	return 0;
+}
+
 static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 			       struct net_buf *buf, uint8_t dlci, uint8_t pf)
 
@@ -1565,8 +1593,6 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 			dlc->ops->recv(dlc, buf);
 		}
 
-		dlc->rx_credit--;
-		rfcomm_dlc_update_credits(dlc);
 	}
 }
 

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -520,6 +520,7 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 	dlc->dlci = dlci;
 	dlc->session = session;
 	dlc->rx_credit = RFCOMM_DEFAULT_CREDIT;
+	dlc->rx_credit_mode = BT_RFCOMM_RX_CREDIT_AUTO;
 	dlc->state = BT_RFCOMM_STATE_INIT;
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
@@ -1522,10 +1523,28 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 	rfcomm_send_credit(dlc, credits);
 }
 
+int bt_rfcomm_dlc_set_rx_credit_mode(struct bt_rfcomm_dlc *dlc, enum bt_rfcomm_rx_credit_mode mode)
+{
+	if (!dlc || !dlc->session) {
+		return -EINVAL;
+	}
+
+	if (mode != BT_RFCOMM_RX_CREDIT_AUTO && mode != BT_RFCOMM_RX_CREDIT_MANUAL) {
+		return -EINVAL;
+	}
+
+	dlc->rx_credit_mode = mode;
+	return 0;
+}
+
 int bt_rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 {
-
 	if (!dlc || !dlc->session) {
+		return -EINVAL;
+	}
+
+	if (dlc->rx_credit_mode == BT_RFCOMM_RX_CREDIT_AUTO) {
+		LOG_WRN("dlc %p is in auto rx credit mode", dlc);
 		return -EINVAL;
 	}
 
@@ -1593,6 +1612,10 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 			dlc->ops->recv(dlc, buf);
 		}
 
+		if (dlc->rx_credit_mode == BT_RFCOMM_RX_CREDIT_AUTO) {
+			dlc->rx_credit--;
+			rfcomm_dlc_update_credits(dlc);
+		}
 	}
 }
 


### PR DESCRIPTION

## Summary

Add flow control to the RX Bluetooth service to resolve data backlog in the protocol stack.

## Impact

rfcomm  recv data

## Testing

btservice test pass
