### PR TITLE
add zblue_settings key commit API.

### DIFF
--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -540,6 +540,17 @@ int settings_call_set_handler(const char *name,
 			      settings_read_cb read_cb,
 			      void *read_cb_arg,
 			      const struct settings_load_arg *load_arg);
+
+/**
+ * Calls settings commit handler.
+ *
+ * @param[in]     name        The name of the data found in the backend.
+ * @param[in,out] load_arg    Arguments for data loading.
+ *
+ * @return 0 or negative error code
+ */
+int settings_call_commit_handler(const char *name,
+				 const struct settings_load_arg *load_arg);
 /**
  * @}
  */

--- a/subsys/settings/include/settings/settings_zblue.h
+++ b/subsys/settings/include/settings/settings_zblue.h
@@ -145,6 +145,20 @@ int settings_zblue_dst(struct settings_zblue* cf);
  */
 int bt_settings_load(uint8_t dev_id, uint8_t id, const char* key, bt_addr_le_t* addr);
 
+/** @brief Commit Bluetooth settings for a device.
+ *
+ * Commits Bluetooth settings for the specified device and key. This function
+ * calls the settings commit handler for the matched settings subtree.
+ *
+ * @param dev_id   Device identifier number.
+ * @param id       identifier number.
+ * @param key      Key string identifying the setting to commit.
+ * @param addr     Remote identity address.
+ *
+ * @return Zero on success, or a negative error code on failure.
+ */
+int bt_settings_commit(uint8_t dev_id, uint8_t id, const char* key, bt_addr_le_t* addr);
+
 /* Initialize a zblue backend. */
 int settings_zblue_backend_init(struct settings_zblue* cf);
 

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -218,7 +218,8 @@ int settings_call_set_handler(const char *name,
 		struct settings_handler_static *ch;
 
 		ch = settings_parse_and_lookup(name, &name_key);
-		if (!ch) {
+		if (!ch || !ch->h_set) {
+			LOG_ERR("No handler for key: %s", name);
 			return 0;
 		}
 
@@ -234,6 +235,37 @@ int settings_call_set_handler(const char *name,
 				name);
 		}
 	}
+	return rc;
+}
+
+int settings_call_commit_handler(const char *name,
+				 const struct settings_load_arg *load_arg)
+{
+	int rc = 0;
+	const char *name_key = name;
+
+	if (load_arg && load_arg->subtree &&
+	    !settings_name_steq(name, load_arg->subtree, &name_key)) {
+		return 0;
+	}
+
+	struct settings_handler_static *ch;
+
+	ch = settings_parse_and_lookup(name, &name_key);
+	if (!ch || !ch->h_commit) {
+		LOG_ERR("No commit handler for key: %s", name);
+		return 0;
+	}
+
+	rc = ch->h_commit();
+	if (rc != 0) {
+		LOG_ERR("commit failure. key: %s error(%d)", name, rc);
+		/* Ignoring the error */
+		rc = 0;
+	} else {
+		LOG_DBG("commit OK. key: %s", name);
+	}
+
 	return rc;
 }
 

--- a/subsys/settings/src/settings_zblue.c
+++ b/subsys/settings/src/settings_zblue.c
@@ -134,6 +134,34 @@ int bt_settings_load(uint8_t dev_id, uint8_t id, const char* key, bt_addr_le_t* 
     return 0;
 }
 
+int bt_settings_commit(uint8_t dev_id, uint8_t id, const char* key, bt_addr_le_t* addr)
+{
+    int err;
+    char id_str[4];
+    char dev_id_str[4];
+    char key_str[BT_SETTINGS_KEY_MAX];
+
+    if (addr) {
+        if (id) {
+            u8_to_dec(id_str, sizeof(id_str), id);
+        }
+
+        u8_to_dec(dev_id_str, sizeof(dev_id_str), dev_id);
+        bt_settings_encode_key(key_str, sizeof(key_str), key, addr, (id ? id_str : NULL), dev_id_str);
+    } else {
+        err = snprintk(key_str, sizeof(key_str), "bt/%s/%d", key, dev_id);
+        if (err < 0) {
+            return -EINVAL;
+        }
+    }
+
+    settings_call_commit_handler(
+        key_str,
+        NULL);
+
+    return 0;
+}
+
 static void parse_settings_key(const char* name, uint8_t* dev_id, uint8_t* id, bt_addr_le_t* addr)
 {
     const char *id_next, *dev_next;


### PR DESCRIPTION
bug: v/85615

After adding LTK/IRK, the stack must trigger the settings commit path so the controller resolving list and related RPA advertise/scan behavior are updated. Previously there was no key-level commit hook for zblue settings, so the commit handler was not invoked for these updates.

This change enables targeted commits for bt/<key>/<dev_id> (and peer-specific keys) without requiring a full settings commit.