### PR TITLE
Bluetooth: Core: add identity addr convert when add/remove white list

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2632,6 +2632,33 @@ static inline void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb)
 #endif
 
 /**
+ * @brief Get peer LE identity address.
+ *
+ * Convert a peer LE address to its identity address when possible.
+ * If @p addr is a Resolvable Private Address (RPA) and can be resolved,
+ * the corresponding identity address will be returned in @p id_addr.
+ * Otherwise, @p id_addr will be a copy of @p addr.
+ *
+ * @param id Bluetooth identity identifier.
+ * @param addr Peer Bluetooth LE address (may be an RPA).
+ * @param id_addr Output identity address.
+ *
+ * @retval 0 Success.
+ * @retval -EAGAIN Bluetooth is not ready.
+ * @retval -EINVAL Invalid arguments.
+ * @retval -ENODEV Bluetooth device not found.
+ */
+int bt_le_identity_addr_get_mc(uint8_t dev_id, uint8_t id, const bt_addr_le_t *addr,
+			       bt_addr_le_t *id_addr);
+#ifdef CONFIG_BT_ORIGINAL_API
+static inline int bt_le_identity_addr_get(uint8_t id, const bt_addr_le_t *addr,
+				 bt_addr_le_t *id_addr)
+{
+	return bt_le_identity_addr_get_mc(0, id, addr, id_addr);
+}
+#endif
+
+/**
  * @brief Add device (LE) to filter accept list.
  *
  * Add peer device LE address to the filter accept list.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4809,6 +4809,45 @@ bool bt_addr_le_is_bonded(struct bt_dev *hdev, uint8_t id, const bt_addr_le_t *a
 	}
 }
 
+int bt_le_identity_addr_get_mc(uint8_t dev_id, uint8_t id, const bt_addr_le_t *addr,
+			      bt_addr_le_t *id_addr)
+{
+	struct bt_dev *hdev;
+
+	if (!addr || !id_addr) {
+		return -EINVAL;
+	}
+
+	if (id >= CONFIG_BT_ID_MAX) {
+		return -EINVAL;
+	}
+
+	hdev = bt_dev_get(dev_id);
+	if (!hdev) {
+		return -ENODEV;
+	}
+
+	if (!atomic_test_bit(hdev->flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
+#if defined(CONFIG_BT_OBSERVER) || defined(CONFIG_BT_BROADCASTER)
+	{
+		const bt_addr_le_t *found;
+
+		found = bt_lookup_id_addr(hdev, id, addr);
+		if (!found) {
+			return -EINVAL;
+		}
+
+		bt_addr_le_copy(id_addr, found);
+	}
+#else
+	bt_addr_le_copy(id_addr, addr);
+#endif
+	return 0;
+}
+
 #if defined(CONFIG_BT_FILTER_ACCEPT_LIST)
 int bt_le_filter_accept_list_add_mc(uint8_t dev_id, const bt_addr_le_t *addr)
 {


### PR DESCRIPTION
bug: v/85615

For example, when adding an RPA address,
the corresponding identity address should be added to the whitelist, not the RPA address itself. Once the peer's RPA address changes, the whitelist adv filter will prevent the peer from reconnecting.