### PR TITLE
Dev spp config

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -48,7 +48,7 @@ config BT_BUF_ACL_TX_COUNT
 
 config BT_BUF_ACL_RX_SIZE
 	int "Maximum supported ACL size for incoming data"
-	default 200 if BT_CLASSIC
+	default 1025 if BT_CLASSIC
 	default 70 if BT_EATT
 	default 69 if BT_SMP
 	default 37 if BT_MESH_GATT

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -77,7 +77,7 @@ config BT_BUF_ACL_RX_SIZE
 
 config BT_BUF_ACL_RX_COUNT_EXTRA
 	int "Number of extra incoming ACL data buffers"
-	default 0
+	default 10
 	range 0 65535
 	help
 	  Number of incoming extra ACL data buffers sent from the Controller to


### PR DESCRIPTION
# Optimize Bluetooth Classic buffer configuration for high throughput

This PR optimizes the Bluetooth Classic buffer configuration to support high-performance RFCOMM data transfers, particularly for BR/EDR 3-DH5 packet handling.

## Changes

### Commit 1: Increase ACL RX buffer size (a191ca168a8)
**Bug:** v/85534

- `BT_BUF_ACL_RX_SIZE`: 200 → 1025 bytes (for `BT_CLASSIC`)
  - Supports BR/EDR 3-DH5 packet size (1021 bytes payload + 4 bytes header)

### Commit 2: Increase ACL RX buffer count (297106e59ce)
**Bug:** v/85754

- `BT_BUF_ACL_RX_COUNT_EXTRA`: 0 → 10
  - Provides sufficient credits to peer devices
  - Prevents stalling due to credit exhaustion during high-speed data transfers

## Benefits

- Enables full utilization of BR/EDR 3-DH5 packet capacity
- Improves RFCOMM throughput performance
- Prevents credit starvation during high-speed data transfers
- Recommended configuration for high-performance RFCOMM reception

## Notes

For systems with limited memory, reducing `BT_BUF_ACL_RX_SIZE` accordingly may be a better choice to optimize memory usage.
