### PR TITLE
Bluetooth: Classic: HFP: HF: parse vendor-specific response payload directly

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -553,16 +553,17 @@ struct bt_hfp_hf_cb {
 	void (*query_call)(struct bt_hfp_hf *hf, struct bt_hfp_hf_current_call *call);
 
 	/** @brief Vendor specific command callback
-	 * 
+	 *
 	 * If this callback is provided it will be called whenever the
 	 * vendor specific result is received from AG.
-	 * If the request is finished, the callback will be called with a NULL rsp.
+	 * If the request is finished, the callback will be called with NULL cmd and value.
 	 * Result code will be provided by the at_cmd_complete callback.
-	 * 
+	 *
 	 * @param hf HFP HF object.
-	 * @param rsp Vendor specific response string.
+	 * @param cmd Vendor specific command name (without leading '+'), or NULL if finished.
+	 * @param value Vendor specific response value, or NULL if finished.
 	 */
-	void (*vendor_specific)(struct bt_hfp_hf *hf, const char *rsp);
+	void (*vendor_specific)(struct bt_hfp_hf *hf, const char *cmd, const char *value);
 
 	/** User-triggered AT command completion callback
 	 *

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -364,37 +364,59 @@ int hfp_hf_send_cmd(struct bt_hfp_hf *hf, at_resp_cb_t resp,
 	return 0;
 }
 
-static int vendor_handle(struct at_client *hf_at)
-{
-	char *val;
-
-	val = at_get_string(hf_at);
-	if (!val) {
-		LOG_ERR("Error getting value");
-		return 0;
-	}
-
-	return 0;
-}
-
 static int vendor_resp(struct at_client *hf_at, struct net_buf *buf)
 {
+	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
+	char *data = (char *)buf->data;
+	int val_len = 0;
+	int err = 0;
+
 	LOG_DBG("Vendor specific response received");
 
-	int err = at_parse_cmd_input(hf_at, buf, "VENDOR", vendor_handle,
-		AT_CMD_TYPE_NORMAL);
+	/* Find the value part until \r */
+	while (val_len < buf->len && data[val_len] != '\r') {
+		val_len++;
+	}
 
-	return err;
+	if (val_len == buf->len) {
+		return -ENODATA;
+	}
+
+	data[val_len] = '\0';
+
+	if (bt_hf && bt_hf->vendor_specific) {
+		bt_hf->vendor_specific(hf, hf_at->buf, data);
+	}
+
+	/* Consume value, \0 and \n from buf */
+	net_buf_pull(buf, val_len);
+
+	err = at_check_byte(buf, '\0');
+	if (err < 0) {
+		LOG_ERR("vendor_resp: expected NUL byte not found");
+		return err;
+	}
+
+	err = at_check_byte(buf, '\n');
+	if (err < 0) {
+		LOG_ERR("vendor_resp: expected LF byte not found");
+		return err;
+	}
+
+	/* Reset AT state for result parsing */
+	hf_at->state = AT_STATE_START;
+
+	return 0;
 }
 
 static int vendor_finish(struct at_client *hf_at, enum bt_at_result result,
 		          enum bt_at_cme cme_err)
 {
 	struct bt_hfp_hf *hf = CONTAINER_OF(hf_at, struct bt_hfp_hf, at);
-	LOG_DBG("Vendor specific response received");
+	LOG_DBG("Vendor specific response finished");
 
 	if (bt_hf && bt_hf->vendor_specific) {
-		bt_hf->vendor_specific(hf, NULL);
+		bt_hf->vendor_specific(hf, NULL, NULL);
 	}
 
 	atomic_clear_bit(hf->flags, BT_HFP_HF_FLAG_VENDOR_PENDING);


### PR DESCRIPTION
depends-on: [ open-vela/frameworks_bluetooth/pull/466 ]

