### PR TITLE
bluetooth: Resolve build errors.

### DIFF
--- a/port/include/zephyr/init.h
+++ b/port/include/zephyr/init.h
@@ -147,9 +147,11 @@ struct init_entry {
  * linker scripts to sort them according to the specified
  * level/priority/sub-priority.
  */
-#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)                           \
+#define Z_INIT_ENTRY_SECTION(level, prio, sub_prio)
+/*
 	__attribute__((__section__(                                           \
 		".z_init_" #level STRINGIFY(prio)"_" STRINGIFY(sub_prio)"_")))
+*/
 
 
 /* Designated initializers where added to C in C99. There were added to


### PR DESCRIPTION
bug: v/85970

Compilation error detected: section .z_init_POST_KERNELCONFIG_KERNEL_INIT_PRIORITY_DEVICE_0_ LMA [10c7825c, 10c7826b] overlaps section .data LMA [10c7825c, 10c7edf3].
