### PR TITLE
pthread: Change 4-byte alignment to 8-byte alignment.

### DIFF
--- a/port/include/zephyr/arch/posix/arch.h
+++ b/port/include/zephyr/arch/posix/arch.h
@@ -33,9 +33,9 @@ extern "C" {
 #include <nuttx/spinlock.h>
 
 #ifdef CONFIG_64BIT
-#define ARCH_STACK_PTR_ALIGN 8
+#define ARCH_STACK_PTR_ALIGN 16
 #else
-#define ARCH_STACK_PTR_ALIGN 4
+#define ARCH_STACK_PTR_ALIGN 8
 #endif
 
 static inline uint32_t arch_k_cycle_get_32(void)


### PR DESCRIPTION
bug: v/73140

The current trunk uses 8-byte alignment for stack addresses, while zblue currently employs 4-byte alignment. This discrepancy triggers a stack alignment check crash during static stack creation.

