### PR TITLE
Add dynamic CTKD mode control for Bluetooth SMP

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2231,6 +2231,38 @@ static inline void bt_le_oob_set_legacy_flag(bool enable)
 }
 #endif
 
+#if defined(CONFIG_BT_CLASSIC)
+/** @brief Cross-Transport Key Derivation (CTKD) mode flags
+ *
+ *  Flags to control dynamic CTKD behavior at runtime during
+ *  Secure Connections pairing.
+ */
+enum bt_smp_ctkd_mode {
+	/** Enable LE LTK to BR/EDR Link Key derivation */
+	BT_SMP_CTKD_LE_TO_BR = BIT(0),
+
+	/** Enable BR/EDR Link Key to LE LTK derivation */
+	BT_SMP_CTKD_BR_TO_LE = BIT(1),
+};
+
+/** @brief Set Cross-Transport Key Derivation (CTKD) mode.
+ *
+ *  Enable or disable CTKD feature dynamically at runtime.
+ *  When enabled, allows derivation of keys across BR/EDR and LE transports
+ *  during Secure Connections pairing.
+ *
+ *  @param dev_id Controller device ID.
+ *  @param ctkd_mode CTKD mode flags (BT_SMP_CTKD_LE_TO_BR | BT_SMP_CTKD_BR_TO_LE).
+ */
+void bt_smp_set_ctkd_mode_mc(uint8_t dev_id, uint8_t ctkd_mode);
+#ifdef CONFIG_BT_ORIGINAL_API
+static inline void bt_smp_set_ctkd_mode(uint8_t ctkd_mode)
+{
+	bt_smp_set_ctkd_mode_mc(0, ctkd_mode);
+}
+#endif
+#endif /* CONFIG_BT_CLASSIC */
+
 /** @brief Set OOB Temporary Key to be used for pairing
  *
  *  This function allows to set OOB data for the LE legacy pairing procedure.

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -596,12 +596,20 @@ done:
 	return err;
 }
 
-static uint8_t get_fixed_channels_mask(void)
+static uint8_t get_fixed_channels_mask(struct bt_dev *hdev)
 {
 	uint8_t mask = 0U;
 
 	/* this needs to be enhanced if AMP Test Manager support is added */
 	STRUCT_SECTION_FOREACH(bt_l2cap_br_fixed_chan, fchan) {
+#if defined(CONFIG_BT_CLASSIC)
+		/* Only advertise BR SMP channel if BR->LE CTKD is enabled */
+		if (fchan->cid == BT_L2CAP_CID_BR_SMP) {
+			if (!bt_smp_ctkd_br_to_le_enabled(hdev)) {
+				continue;
+			}
+		}
+#endif
 		mask |= BIT(fchan->cid);
 	}
 
@@ -646,7 +654,7 @@ static int l2cap_br_info_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		rsp->result = sys_cpu_to_le16(BT_L2CAP_INFO_SUCCESS);
 		/* fixed channel mask protocol data is 8 octets wide */
 		(void)memset(net_buf_add(rsp_buf, 8), 0, 8);
-		rsp->data[0] = get_fixed_channels_mask();
+		rsp->data[0] = get_fixed_channels_mask(conn->hdev);
 
 		hdr_info->len = sys_cpu_to_le16(sizeof(*rsp) + 8);
 		break;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -286,6 +286,10 @@ struct bt_dev_smp_ctx {
 	bool sc_supported;
 	const uint8_t *sc_public_key;
 	struct k_sem sc_local_pkey_ready;
+#if defined(CONFIG_BT_CLASSIC)
+	bool ctkd_le_to_br_enabled;
+	bool ctkd_br_to_le_enabled;
+#endif
 } smp_ctx_pool[CONFIG_BT_NUM_CTLRS];
 
 #define DISPLAY_FIXED(smp) (IS_ENABLED(CONFIG_BT_FIXED_PASSKEY) && \
@@ -1283,6 +1287,11 @@ static bool smp_br_pairing_allowed(struct bt_smp_br *smp)
 	}
 
 	conn = smp->chan.chan.conn;
+
+	/* Check if CTKD is enabled for BR/EDR to LE */
+	if (!conn->hdev->smp_ctx->ctkd_br_to_le_enabled) {
+		return false;
+	}
 
 	addr.type = BT_ADDR_LE_PUBLIC;
 	bt_addr_copy(&addr.a, &conn->br.dst);
@@ -2944,6 +2953,32 @@ void bt_le_oob_set_legacy_flag_mc(uint8_t dev_id, bool enable)
 	hdev->smp_ctx->legacy_oobd_present = enable;
 }
 
+#if defined(CONFIG_BT_CLASSIC)
+bool bt_smp_ctkd_br_to_le_enabled(struct bt_dev *hdev)
+{
+	if (!hdev || !hdev->smp_ctx) {
+		return false;
+	}
+
+	return hdev->smp_ctx->ctkd_br_to_le_enabled;
+}
+
+void bt_smp_set_ctkd_mode_mc(uint8_t dev_id, uint8_t ctkd_mode)
+{
+	struct bt_dev *hdev = bt_dev_get(dev_id);
+	if (!hdev) {
+		return;
+	}
+
+	hdev->smp_ctx->ctkd_le_to_br_enabled = (ctkd_mode & BT_SMP_CTKD_LE_TO_BR) ? true : false;
+	hdev->smp_ctx->ctkd_br_to_le_enabled = (ctkd_mode & BT_SMP_CTKD_BR_TO_LE) ? true : false;
+
+	LOG_DBG("CTKD mode set: LE->BR %s, BR->LE %s",
+		hdev->smp_ctx->ctkd_le_to_br_enabled ? "enabled" : "disabled",
+		hdev->smp_ctx->ctkd_br_to_le_enabled ? "enabled" : "disabled");
+}
+#endif /* CONFIG_BT_CLASSIC */
+
 static uint8_t get_auth(struct bt_smp *smp, uint8_t auth)
 {
 	struct bt_conn *conn = smp->chan.chan.conn;
@@ -3260,6 +3295,13 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 
 		rsp->init_key_dist &= RECV_KEYS_SC;
 		rsp->resp_key_dist &= SEND_KEYS_SC;
+#if defined(CONFIG_BT_CLASSIC)
+		/* LE SC: remove linkkey distribution if CTKD LE->BR is disabled */
+		if (!hdev->smp_ctx->ctkd_le_to_br_enabled) {
+			rsp->init_key_dist &= ~LINK_DIST;
+			rsp->resp_key_dist &= ~LINK_DIST;
+		}
+#endif
 	}
 
 	if (atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
@@ -3578,6 +3620,13 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 
 	smp->local_dist &= SEND_KEYS_SC;
 	smp->remote_dist &= RECV_KEYS_SC;
+#if defined(CONFIG_BT_CLASSIC)
+	/* LE SC: remove linkkey distribution if CTKD LE->BR is disabled */
+	if (!hdev->smp_ctx->ctkd_le_to_br_enabled) {
+		smp->local_dist &= ~LINK_DIST;
+		smp->remote_dist &= ~LINK_DIST;
+	}
+#endif
 
 	if (IS_ENABLED(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)) {
 		err = smp_pairing_accept_query(smp, rsp);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -876,8 +876,8 @@ static void sc_derive_link_key(struct bt_smp *smp)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->hdev->bt_auth_info_cbs, listener,
 						next, node) {
 		if (listener->pairing_complete_ctkd) {
-			/* Derive BR Link Key over LE link */
-			listener->pairing_complete_ctkd(conn, bond_flag);
+			/* Derive BR Link Key over LE link , is_linkkey = true */
+			listener->pairing_complete_ctkd(conn, true);
 		}
 	}
 
@@ -975,8 +975,8 @@ static void smp_pairing_br_complete(struct bt_smp_br *smp, uint8_t status)
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->hdev->bt_auth_info_cbs, listener,
 						  next, node) {
 			if (listener->pairing_complete_ctkd) {
-				/* Derive LE LTK over BR conn */
-				listener->pairing_complete_ctkd(conn, bond_flag);
+				/* Derive LE LTK over BR conn , is_linkkey = false */
+				listener->pairing_complete_ctkd(conn, false);
 			}
 		}
 

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -202,3 +202,7 @@ static inline const char *bt_smp_err_to_str(uint8_t smp_err)
 	return "";
 }
 #endif
+
+#if defined(CONFIG_BT_CLASSIC)
+bool bt_smp_ctkd_br_to_le_enabled(struct bt_dev *hdev);
+#endif


### PR DESCRIPTION
    rootcause: Implement runtime CTKD (Cross-Transport Key Derivation) control that only applies to LE Secure Connections pairing, not legacy pairing. Legacy pairing always removes LINK_DIST flags to avoid key derivation conflicts.
    
    Changes:
    1. Add CTKD mode enum and APIs in conn.h for runtime control
    2. Add CTKD state storage (ctkd_le_to_br_enabled, ctkd_br_to_le_enabled) in bt_dev_smp_ctx
    3. Implement bt_smp_set_ctkd_mode_mc() and bt_smp_get_ctkd_mode_mc() functions
    4. Add CTKD checks in BR/EDR pairing functions (smp_br_pairing_req, bt_smp_br_send_pairing_req)
    5. Add CTKD control in LE SC pairing (smp_pairing_req, smp_pairing_rsp) to conditionally remove LINK_DIST
    6. Modify get_fixed_channels_mask() to check CTKD configuration for BR SMP channel advertisement
    
    This allows dynamic enabling/disabling of CTKD feature at runtime, providing flexibility for different pairing scenarios.
    
    Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>