### PR TITLE
bluetooth: keys: clear BR/EDR key pool on reset

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -83,6 +83,9 @@ void bt_keys_reset(struct bt_dev *hdev)
 	hdev->keys = &key_pool[hdev->dev_id];
 
 	memset(&hdev->keys->key_pool, 0, sizeof(hdev->keys->key_pool));
+#if defined(CONFIG_BT_CLASSIC)
+	memset(&hdev->keys->br_key_pool, 0, sizeof(hdev->keys->br_key_pool));
+#endif
 }
 
 struct bt_keys *bt_keys_get_addr(struct bt_dev *hdev, uint8_t id, const bt_addr_le_t *addr)


### PR DESCRIPTION
bug: v/85716

Also reset br_key_pool when CONFIG_BT_CLASSIC is enabled to avoid stale link keys after bt_keys_reset.