### PR TITLE
Bluetooth: host: derive IR from BD_ADDR using product-specific CMAC key

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -505,6 +505,23 @@ config BT_PRIVACY_RANDOMIZE_IR
 	  identity for each entry in Read_Static_Addresses. Setting this config
 	  randomizes the IRs during this process.
 
+config BT_PRIVACY_ERIR
+	bool "Derive identity root from BD_ADDR using product-specific CMAC key"
+	depends on BT_PRIVACY
+	default n
+	help
+	  When enabled, the identity root (IR) is derived from the device's
+	  BD_ADDR using AES-CMAC with a product-specific private key, instead
+	  of reading it from the controller via bt_read_identity_root().
+
+config BT_PRIVACY_ERIR_CMAC_KEY
+	string "Product-specific CMAC private key for IR derivation"
+	depends on BT_PRIVACY_ERIR
+	help
+	  16-byte product-specific private key (Big-endian) used by AES-CMAC
+	  to derive the identity root from BD_ADDR. SHOULD be changed for
+	  different releases/products.
+
 config BT_RPA_TIMEOUT
 	int "Resolvable Private Address timeout"
 	depends on BT_PRIVACY

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -42,6 +42,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_id);
 
+#if defined(CONFIG_BT_PRIVACY_ERIR)
+#define SMP_CMAC_PRIVATE_KEY   CONFIG_BT_PRIVACY_ERIR_CMAC_KEY
+BUILD_ASSERT(sizeof(CONFIG_BT_PRIVACY_ERIR_CMAC_KEY) - 1 == 16,
+	     "BT_PRIVACY_ERIR_CMAC_KEY must be exactly 16 bytes");
+#endif
+
 struct bt_adv_id_check_data {
 	uint8_t id;
 	bool adv_enabled;
@@ -1617,6 +1623,42 @@ static bool irk_is_empty(const uint8_t* irk)
 	return true;
 }
 
+#if defined(CONFIG_BT_PRIVACY_ERIR)
+static int bt_calc_erir(const bt_addr_le_t *addr, const uint8_t *key_id, uint8_t *ir)
+{
+	/*
+	 * Product-specific CMAC key, Big-endian.
+	 */
+	uint8_t key_be[16];
+
+	/* data = BD_ADDR(7 bytes) || key_id(2 bytes), Big-endian*/
+	uint8_t data[7 + 2];
+	int err;
+
+	memcpy(key_be, SMP_CMAC_PRIVATE_KEY, 16);
+	sys_mem_swap(key_be, 16);
+
+	/* BD_ADDR: address (6 bytes) + address type (1 byte) */
+	memcpy(&data[0], addr->a.val, 6);
+	data[6] = addr->type;
+
+	/* key_id: "IR" (2 bytes) */
+	memcpy(&data[7], key_id, 2);
+	sys_mem_swap(data, 7 + 2);
+
+	err = bt_crypto_aes_cmac(key_be, data, sizeof(data), ir);
+	if (err) {
+		LOG_ERR("IR generation failed");
+		return err;
+	}
+
+	/* Big-endian output */
+	sys_mem_swap(ir, 16);
+	LOG_DBG("IR create: %s", bt_hex(ir, 16));
+	return 0;
+}
+#endif /* defined(CONFIG_BT_PRIVACY_ERIR) */
+
 int bt_setup_public_id_addr(struct bt_dev *hdev)
 {
 	bt_addr_le_t addr;
@@ -1630,13 +1672,18 @@ int bt_setup_public_id_addr(struct bt_dev *hdev)
 
 	if (!irk_is_empty(hdev->irk[BT_ID_DEFAULT])) {
 		irk = hdev->irk[BT_ID_DEFAULT];
+		goto out;
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
 	uint8_t ir_irk[16];
-	uint8_t ir[16];
+	uint8_t ir[16] = { 0 };
 
+#if defined(CONFIG_BT_PRIVACY_ERIR)
+	bt_calc_erir(&addr, (uint8_t*)"IR", ir);
+#else
 	bt_read_identity_root(hdev, ir);
+#endif /* defined(CONFIG_BT_PRIVACY_ERIR) */
 
 	if (!IS_ENABLED(CONFIG_BT_PRIVACY_RANDOMIZE_IR)) {
 		if (!bt_smp_irk_get(ir, ir_irk)) {
@@ -1645,6 +1692,7 @@ int bt_setup_public_id_addr(struct bt_dev *hdev)
 	}
 #endif /* defined(CONFIG_BT_PRIVACY) */
 
+out:
 	/* If true, `id_create` will randomize the IRK. */
 	if (!irk && IS_ENABLED(CONFIG_BT_PRIVACY)) {
 		/* `id_create` will not store the id when called before BT_DEV_READY.


### PR DESCRIPTION
bug: v/85864

rootcause: The original bt_read_identity_root() reads IR from controller, which may not be available or stable across different products. A product-specific IR derivation is needed to ensure consistent identity root generation.

Changes:
1. Add bt_calc_erir() to derive IR from BD_ADDR using AES-CMAC with a product-specific private key
2. Replace bt_read_identity_root() with bt_calc_erir() in bt_setup_public_id_addr()
3. Skip IR derivation when a valid IRK already exists in hdev->irk
4. Fix inverted condition and comment in bt_setup_public_id_addr()

