### PR TITLE
Complete bt_gatt_reset path.

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1605,6 +1605,7 @@ void bt_gatt_init(struct bt_dev *hdev)
 {
 	struct bt_dev_gatt_ctx *gatt_ctx = &gatt_ctx_pool[hdev->dev_id];
 	hdev->gatt_ctx = gatt_ctx;
+	memset(hdev->gatt_ctx, 0, sizeof(*hdev->gatt_ctx));
 	gatt_ctx->hdev = hdev;
 
 	sys_slist_init(&gatt_ctx->callback_list);


### PR DESCRIPTION
bug: v/85867

rootcause:
During enable/disable reset lifecycle, GATT lacked a symmetric reset entry for gatt_ctx. This patch supplements the missing bt_gatt_reset API and adds calls at the same lifecycle points to make context zeroing explicit and consistent.

