### PR TITLE
hfp_ag: add features parameter to bt_hfp_ag_register

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -506,10 +506,14 @@ struct bt_hfp_ag_cb {
  *  required HFP details to display.
  *
  *  @param cb callback structure.
+ *  @param features Requested AG supported features bitmask. If 0, the compile-time
+ *         default BT_HFP_AG_SUPPORTED_FEATURES will be used. If non-zero, only the
+ *         features that are both requested and compile-time enabled will be adopted.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @return Negative value in case of error, or the actually adopted features
+ *          bitmask (>= 0) on success.
  */
-int Z_API(bt_hfp_ag_register)(struct bt_hfp_ag_cb *cb);
+int32_t Z_API(bt_hfp_ag_register)(struct bt_hfp_ag_cb *cb, uint32_t features);
 
 /** @brief Create the hfp ag session
  *

--- a/samples/bluetooth/handsfree_ag/src/main.c
+++ b/samples/bluetooth/handsfree_ag/src/main.c
@@ -381,7 +381,7 @@ static void bt_ready(int err)
 
 	bt_br_discovery_cb_register(&discovery_cb);
 
-	Z_API(bt_hfp_ag_register)(&ag_cb);
+	Z_API(bt_hfp_ag_register)(&ag_cb, 0);
 
 	k_work_init(&discover_work, discover_work_handler);
 

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -72,6 +72,7 @@ NET_BUF_POOL_FIXED_DEFINE(ag_pool, CONFIG_BT_HFP_AG_TX_BUF_COUNT,
 static struct bt_hfp_ag bt_hfp_ag_pool[CONFIG_BT_MAX_CONN];
 
 static struct bt_hfp_ag_cb *bt_ag;
+static uint32_t bt_ag_registered_features;
 
 #define AG_SUPT_FEAT(ag, _feature) ((ag->ag_features & (_feature)) != 0)
 #define HF_SUPT_FEAT(ag, _feature) ((ag->hf_features & (_feature)) != 0)
@@ -3959,7 +3960,7 @@ static struct bt_hfp_ag *hfp_ag_create(struct bt_conn *conn)
 	ag->rfcomm_dlc.mtu = BT_HFP_MAX_MTU;
 
 	/* Set the supported features*/
-	ag->ag_features = BT_HFP_AG_SUPPORTED_FEATURES;
+	ag->ag_features = bt_ag_registered_features;
 	ag->ag_features |= BT_FEAT_SC(conn->hdev->features) ? BT_HFP_AG_FEATURE_ESCO_S4 : 0;
 
 	/* Support HF indicators */
@@ -4170,7 +4171,7 @@ static void hfp_ag_deinit(void)
 	bt_sco_conn_cb_unregister(&ag_sco_conn_cb);
 }
 
-int Z_API(bt_hfp_ag_register)(struct bt_hfp_ag_cb *cb)
+int32_t Z_API(bt_hfp_ag_register)(struct bt_hfp_ag_cb *cb, uint32_t features)
 {
 	if (!cb) {
 		return -EINVAL;
@@ -4181,10 +4182,13 @@ int Z_API(bt_hfp_ag_register)(struct bt_hfp_ag_cb *cb)
 	}
 
 	bt_ag = cb;
+	bt_ag_registered_features = features ?
+		(features & BT_HFP_AG_SUPPORTED_FEATURES) :
+		BT_HFP_AG_SUPPORTED_FEATURES;
 
 	hfp_ag_init();
 
-	return 0;
+	return (int32_t)bt_ag_registered_features;
 }
 
 int Z_API(bt_hfp_ag_unregister)(void)
@@ -4196,6 +4200,7 @@ int Z_API(bt_hfp_ag_unregister)(void)
 	hfp_ag_disconnect_all();
 	
 	bt_ag = NULL;
+	bt_ag_registered_features = 0;
 
 	hfp_ag_deinit();
 

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -1365,16 +1365,17 @@ static struct bt_hfp_ag_cb ag_cb = {
 
 static int cmd_ag_reg_enable(const struct shell *sh, size_t argc, char **argv)
 {
-	int err;
+	int32_t ret;
 
-	err = bt_hfp_ag_register(&ag_cb);
-	if (err) {
-		shell_error(sh, "Callback register failed: %d", err);
+	ret = bt_hfp_ag_register(&ag_cb, 0);
+	if (ret < 0) {
+		shell_error(sh, "Callback register failed: %d", ret);
+		return ret;
 	}
 
-	return err;
+	shell_print(sh, "AG registered, features: 0x%08x", (uint32_t)ret);
+	return 0;
 }
-
 static int cmd_ag_connect(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;


### PR DESCRIPTION
bug: v/86209

Allow callers to specify requested AG supported features at registration time. The actually adopted features are the intersection of the requested features and the compile-time BT_HFP_AG_SUPPORTED_FEATURES. Passing 0 falls back to the compile-time default.

The return value is changed from int to int32_t and now returns the adopted features bitmask on success instead of 0.

