### PR TITLE
bluetooth: hfp_ag: add CHLD execute command passthrough callback

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -468,6 +468,17 @@ struct bt_hfp_ag_cb {
 	void (*hf_indicator_value)(struct bt_hfp_ag *ag, enum hfp_ag_hf_indicators indicator,
 				   uint32_t value);
 
+	/** AT+CHLD execute command passthrough callback
+	 *
+	 *  If this callback is provided it will be called whenever an AT+CHLD=<value>
+	 *  execute command is received from HF, before the stack processes it internally.
+	 *  This allows the upper layer to observe all CHLD commands.
+	 *
+	 *  @param ag HFP AG object.
+	 *  @param value The CHLD command value (e.g. 0, 1, 2, 3, 4, 11, 21, ...).
+	 */
+	void (*chld)(struct bt_hfp_ag *ag, uint32_t value);
+
 	/** Vendor specific / custom AT command callback
 	 *
 	 *  If this callback is provided it will be called whenever an AT command

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2121,6 +2121,11 @@ static int bt_hfp_ag_chld_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 		return -ENOTSUP;
 	}
 
+	/* Notify upper layer before processing internally */
+	if (bt_ag && bt_ag->chld) {
+		bt_ag->chld(ag, value);
+	}
+
 	switch (value) {
 	case BT_HFP_CHLD_RELEASE_ALL:
 		return chld_release_all(ag);


### PR DESCRIPTION
bug: v/86209

Add chld callback to bt_hfp_ag_cb that fires before the stack processes AT+CHLD=<value> internally, allowing the upper layer to observe all CHLD execute commands. The AT+CHLD=? query path remains unchanged.

