### PR TITLE
hfp_ag: disable in-band ring by default

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -355,7 +355,7 @@ config BT_HFP_AG_GET_ONGOING_CALL_TIMEOUT
 
 config BT_HFP_AG_INBAND_RINGTONE
 	bool "In-band ring tone capability"
-	default y
+	default n
 	help
 	  This option enables In-band ring tone capability
 


### PR DESCRIPTION
bug: v/83723

Rootcause: in-band ring not supported


