### PR TITLE
Bluetooth: SDP: Increase max services from 10 to 15

### DIFF
--- a/subsys/bluetooth/host/classic/sdp_internal.h
+++ b/subsys/bluetooth/host/classic/sdp_internal.h
@@ -37,7 +37,7 @@
 #define BT_SDP_INVALID_PDU_SIZE      0x0004
 #define BT_SDP_INVALID_CSTATE        0x0005
 
-#define BT_SDP_MAX_SERVICES   10
+#define BT_SDP_MAX_SERVICES   16
 
 struct bt_sdp_data_elem_seq {
 	uint8_t  type; /* Type: Will be data element sequence */


### PR DESCRIPTION
bug: v/87626

Current BT_SDP_MAX_SERVICES=10 is insufficient for all profile registrations. The following services need SDP registration:
- bt_conn_init (zblue internal)
- A2DP source
- AVRCP target
- HFP HF
- HFP AG
- SPP server (multiple instances)
- GATTS (multiple instances)
- HID device

When SPP server starts a second instance, it fails with "Reached max allowed registrations" error.

Increase BT_SDP_MAX_SERVICES to 15 to accommodate all services.