### PR TITLE
bluetooth: hfp_hf: fix deadlock in hfp_hf_send_cmd due to K_FOREVER b…

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -335,7 +335,10 @@ int hfp_hf_send_cmd(struct bt_hfp_hf *hf, at_resp_cb_t resp,
 	va_list vargs;
 	int ret;
 
-	buf = bt_rfcomm_create_pdu(&hf_pool);
+	buf = bt_conn_create_pdu_timeout(&hf_pool,
+			sizeof(struct bt_l2cap_hdr) +
+			sizeof(struct bt_rfcomm_hdr) + 1,
+			K_NO_WAIT);
 	if (!buf) {
 		LOG_ERR("No Buffers!");
 		return -ENOMEM;


### PR DESCRIPTION
…uf alloc

bug: v/87673

When stress-testing volume adjustment during iOS call, hfp_hf_send_cmd calls bt_rfcomm_create_pdu which uses K_FOREVER timeout for net_buf_alloc. The hf_pool has only 6 buffers (CONFIG_BT_MAX_CONN+1). Under rapid volume changes, all buffers are queued in tx_pending FIFO waiting for serial AT command completion, causing the 7th allocation to block forever. This blocks the BT thread and IPC channel, freezing MiWear on AP side.

Replace bt_rfcomm_create_pdu (K_FOREVER) with bt_conn_create_pdu_timeout using K_NO_WAIT, so pool exhaustion returns -ENOMEM immediately instead of blocking indefinitely.


