### PR TITLE
Bluetooth: Host: Allow bypassing RPA for LE connection with privacy enabled

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -538,6 +538,17 @@ config BT_RPA_TIMEOUT_DYNAMIC
 	  This option allows the user to override the default value of
 	  the Resolvable Private Address timeout using dedicated APIs.
 
+config BT_CENTRAL_FORCE_IDENTITY_ADDR
+	bool "Force identity address when initiating LE connections"
+	depends on BT_PRIVACY && BT_CENTRAL
+	default y
+	help
+	  When enabled, the initiator uses its identity address (public or
+	  random static) instead of a Resolvable Private Address (RPA) when
+	  creating LE connections, even if CONFIG_BT_PRIVACY is enabled.
+	  This is needed when the remote device does not support privacy or
+	  requires a fixed address from the initiator.
+
 config BT_RPA_SHARING
 	bool "Share the Resolvable Private Address between advertising sets"
 	depends on BT_PRIVACY && BT_EXT_ADV

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1835,7 +1835,8 @@ int bt_id_set_create_conn_own_addr(struct bt_dev *hdev, bool use_filter, uint8_t
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
+	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    !IS_ENABLED(CONFIG_BT_CENTRAL_FORCE_IDENTITY_ADDR)) {
 		if (use_filter || rpa_timeout_valid_check(hdev)) {
 			err = bt_id_set_private_addr(hdev, BT_ID_DEFAULT);
 			if (err) {


### PR DESCRIPTION
bug: v/87917

Add BT_CONN_LE_OPT_USE_IDENTITY_ADDR option to bt_conn_le_create_param. When set, the initiator uses its identity address (public or random static) instead of an RPA, even if CONFIG_BT_PRIVACY is enabled. This is needed when the remote device does not support privacy or requires a fixed address from the initiator.
