### PR TITLE
feat: add zero-copy APIs for GATT RX/TX path

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1363,6 +1363,8 @@ struct bt_gatt_notify_params {
 #if defined(CONFIG_BT_EATT)
 	enum bt_att_chan_opt chan_opt;
 #endif /* CONFIG_BT_EATT */
+	/** Pre-built ATT PDU for zero-copy TX (optional) */
+	struct net_buf *pdu;
 };
 
 /** @brief Notify attribute value change.
@@ -1388,6 +1390,21 @@ struct bt_gatt_notify_params {
  */
 int bt_gatt_notify_cb(struct bt_conn *conn,
 		      struct bt_gatt_notify_params *params);
+
+struct net_buf *bt_gatt_alloc_notify_pdu(struct bt_conn *conn,
+					 uint16_t handle, size_t len);
+
+struct net_buf *bt_gatt_alloc_indicate_pdu(struct bt_conn *conn,
+					   uint16_t handle, size_t len);
+
+struct net_buf *bt_gatt_alloc_write_cmd_pdu(struct bt_conn *conn,
+					    uint16_t handle, size_t len,
+					    bool sign);
+
+int bt_gatt_write_without_response_cb_zerocopy(struct bt_conn *conn,
+					       struct net_buf *pdu,
+					       bt_gatt_complete_func_t func,
+					       void *user_data);
 
 /** @brief Send multiple notifications in a single PDU.
  *
@@ -1564,6 +1581,8 @@ struct bt_gatt_indicate_params {
 #if defined(CONFIG_BT_EATT)
 	enum bt_att_chan_opt chan_opt;
 #endif /* CONFIG_BT_EATT */
+	/** Pre-built ATT PDU for zero-copy TX (optional) */
+	struct net_buf *pdu;
 };
 
 /** @brief Indicate attribute value change.
@@ -2023,6 +2042,8 @@ struct bt_gatt_write_params {
 #if defined(CONFIG_BT_EATT)
 	enum bt_att_chan_opt chan_opt;
 #endif /* CONFIG_BT_EATT */
+	/** Pre-built ATT PDU for zero-copy TX (optional) */
+	struct net_buf *pdu;
 };
 
 /** @brief Write Attribute Value by handle

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -118,6 +118,7 @@ struct bt_att_chan {
 	struct bt_att_req	*req;
 	struct k_fifo		tx_queue;
 	struct k_work_delayable	timeout_work;
+	struct net_buf		*current_buf;
 	sys_snode_t		node;
 };
 
@@ -3083,7 +3084,9 @@ static int bt_att_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		LOG_ERR("Invalid len %u for code 0x%02x", buf->len, hdr->code);
 		err = BT_ATT_ERR_INVALID_PDU;
 	} else {
+		att_chan->current_buf = buf;
 		err = handler->func(att_chan, buf);
+		att_chan->current_buf = NULL;
 	}
 
 	if (handler->type == ATT_REQUEST && err) {
@@ -3134,6 +3137,24 @@ static struct bt_att *att_get(struct bt_conn *conn)
 	}
 
 	return att_chan->att;
+}
+
+struct net_buf *bt_att_get_current_buf(struct bt_conn *conn)
+{
+	struct bt_l2cap_chan *chan;
+	struct bt_att_chan *att_chan;
+
+	if (!conn || conn->state != BT_CONN_CONNECTED) {
+		return NULL;
+	}
+
+	chan = bt_l2cap_le_lookup_rx_cid(conn, BT_L2CAP_CID_ATT);
+	if (!chan) {
+		return NULL;
+	}
+
+	att_chan = ATT_CHAN(chan);
+	return att_chan->current_buf;
 }
 
 struct net_buf *bt_att_create_pdu(struct bt_conn *conn, uint8_t op, size_t len)

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -352,3 +352,6 @@ bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_gatt_complete_func_
 bool bt_att_chan_opt_valid(struct bt_conn *conn, enum bt_att_chan_opt chan_opt);
 
 void bt_gatt_req_set_mtu(struct bt_att_req *req, uint16_t mtu);
+
+/* Get the current ATT RX net_buf being processed (for zero-copy) */
+struct net_buf *bt_att_get_current_buf(struct bt_conn *conn);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2642,6 +2642,15 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 	}
 #endif /* CONFIG_BT_GATT_NOTIFY_MULTIPLE */
 
+	/* Zero-copy path: use pre-built PDU if provided */
+	if (params->pdu) {
+		buf = params->pdu;
+		LOG_DBG("conn %p handle 0x%04x (zero-copy)", conn, handle);
+		bt_att_set_tx_meta_data(buf, params->func, params->user_data, BT_ATT_CHAN_OPT(params));
+		params->pdu = NULL;
+		return bt_att_send(conn, buf);
+	}
+
 	buf = bt_att_create_pdu(conn, BT_ATT_OP_NOTIFY,
 				sizeof(*nfy) + params->len);
 	if (!buf) {
@@ -2811,6 +2820,13 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 		return -ENOMEM;
 	}
 
+	/* Zero-copy path: use pre-built PDU if provided */
+	if (params->pdu) {
+		buf = params->pdu;
+		LOG_DBG("conn %p handle 0x%04x (zero-copy indicate)", conn, handle);
+		bt_att_set_tx_meta_data(buf, NULL, NULL, BT_ATT_CHAN_OPT(params));
+		params->pdu = NULL;
+	} else {
 	buf = bt_att_create_pdu(conn, BT_ATT_OP_INDICATE, len);
 	if (!buf) {
 		LOG_WRN("No buffer available to send indication");
@@ -2825,6 +2841,7 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 
 	net_buf_add(buf, params->len);
 	memcpy(ind->value, params->data, params->len);
+	}
 
 	LOG_DBG("conn %p handle 0x%04x", conn, handle);
 
@@ -5302,6 +5319,26 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 
 	return bt_att_send(conn, buf);
 }
+
+int bt_gatt_write_without_response_cb_zerocopy(struct bt_conn *conn,
+						       struct net_buf *pdu,
+						       bt_gatt_complete_func_t func,
+						       void *user_data)
+{
+	__ASSERT(conn, "invalid parameters\n");
+	__ASSERT(pdu, "invalid parameters\n");
+
+	if (conn->state != BT_CONN_CONNECTED) {
+		net_buf_unref(pdu);
+		return -ENOTCONN;
+	}
+
+	LOG_DBG("zero-copy write cmd");
+
+	bt_att_set_tx_meta_data(pdu, func, user_data, BT_ATT_CHAN_OPT_NONE);
+
+	return bt_att_send(conn, pdu);
+}
 #endif /* CONFIG_BT_GATT_CLIENT */
 
 int bt_gatt_send_read_rsp(struct bt_conn *conn, int err, uint16_t handle,
@@ -5599,6 +5636,28 @@ int bt_gatt_write(struct bt_conn *conn, struct bt_gatt_write_params *params)
 	}
 
 	LOG_DBG("handle 0x%04x length %u", params->handle, params->length);
+
+	/* Zero-copy path: use pre-built PDU */
+	if (params->pdu) {
+		struct bt_att_req *req;
+
+		req = gatt_req_alloc(conn->hdev, gatt_write_rsp, params, NULL,
+				     BT_ATT_OP_WRITE_REQ, len);
+		if (!req) {
+			return -ENOMEM;
+		}
+
+		bt_att_set_tx_meta_data(params->pdu, NULL, NULL,
+					   BT_ATT_CHAN_OPT(params));
+		req->buf = params->pdu;
+		params->pdu = NULL;
+
+		int err = bt_att_req_send(conn, req);
+		if (err) {
+			bt_att_req_free(req);
+		}
+		return err;
+	}
 
 	return gatt_req_send(conn, gatt_write_rsp, params, gatt_write_encode,
 			     BT_ATT_OP_WRITE_REQ, len, BT_ATT_CHAN_OPT(params));
@@ -6881,4 +6940,74 @@ void bt_gatt_req_set_mtu(struct bt_att_req *req, uint16_t mtu)
 	 * just drop it here. Feel free to add this capability to other
 	 * request types if needed.
 	 */
+
+}
+/* Zero-copy TX: PDU allocation helpers */
+struct net_buf *bt_gatt_alloc_notify_pdu(struct bt_conn *conn,
+					 uint16_t handle, size_t len)
+{
+	struct net_buf *buf;
+	struct bt_att_notify *nfy;
+
+	buf = bt_att_create_pdu(conn, BT_ATT_OP_NOTIFY,
+				sizeof(*nfy) + len);
+	if (!buf) {
+		return NULL;
+	}
+
+	nfy = net_buf_add(buf, sizeof(*nfy));
+	nfy->handle = sys_cpu_to_le16(handle);
+
+	/* Reserve space for payload - caller writes data here */
+	net_buf_add(buf, len);
+
+	return buf;
+}
+
+struct net_buf *bt_gatt_alloc_indicate_pdu(struct bt_conn *conn,
+					   uint16_t handle, size_t len)
+{
+	struct net_buf *buf;
+	struct bt_att_indicate *ind;
+
+	buf = bt_att_create_pdu(conn, BT_ATT_OP_INDICATE,
+				sizeof(*ind) + len);
+	if (!buf) {
+		return NULL;
+	}
+
+	ind = net_buf_add(buf, sizeof(*ind));
+	ind->handle = sys_cpu_to_le16(handle);
+
+	/* Reserve space for payload - caller writes data here */
+	net_buf_add(buf, len);
+
+	return buf;
+}
+
+struct net_buf *bt_gatt_alloc_write_cmd_pdu(struct bt_conn *conn,
+					    uint16_t handle, size_t len,
+					    bool sign)
+{
+	struct net_buf *buf;
+	struct bt_att_write_cmd *cmd;
+
+	if (sign) {
+		buf = bt_att_create_pdu(conn, BT_ATT_OP_SIGNED_WRITE_CMD,
+					sizeof(*cmd) + len + 12);
+	} else {
+		buf = bt_att_create_pdu(conn, BT_ATT_OP_WRITE_CMD,
+					sizeof(*cmd) + len);
+	}
+	if (!buf) {
+		return NULL;
+	}
+
+	cmd = net_buf_add(buf, sizeof(*cmd));
+	cmd->handle = sys_cpu_to_le16(handle);
+
+	/* Reserve space for payload - caller writes data here */
+	net_buf_add(buf, len);
+
+	return buf;
 }


### PR DESCRIPTION
- bt_att_get_current_buf(): get current ATT PDU net_buf in callbacks
- bt_gatt_alloc_notify_pdu(): pre-allocate notify PDU for zero-copy TX
- bt_gatt_alloc_indicate_pdu(): pre-allocate indicate PDU for zero-copy TX
- bt_gatt_alloc_write_cmd_pdu(): pre-allocate write cmd PDU for zero-copy TX

These APIs enable upper layers to avoid intermediate malloc/memcpy by directly referencing or writing to Zephyr's net_buf.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

