### PR TITLE
Bluetooth: host: reject MTU Exchange over BR/EDR

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -869,6 +869,12 @@ static uint8_t att_mtu_req(struct bt_att_chan *chan, struct net_buf *buf)
 		return BT_ATT_ERR_NOT_SUPPORTED;
 	}
 
+#if defined(CONFIG_BT_ATT_OVER_BR)
+	if (bt_att_is_over_br(chan)) {
+		return BT_ATT_ERR_NOT_SUPPORTED;
+	}
+#endif /* CONFIG_BT_ATT_OVER_BR */
+
 	req = (void *)buf->data;
 
 	mtu_client = sys_le16_to_cpu(req->mtu);


### PR DESCRIPTION
## Summary
Reject ATT MTU Exchange Request when ATT channel runs over BR/EDR transport.
The MTU Exchange procedure is only defined for LE, so when CONFIG_BT_ATT_OVER_BR
is enabled, att_mtu_req() should return BT_ATT_ERR_NOT_SUPPORTED for BR/EDR channels.

## Impact
No impact on LE ATT behavior. Only affects BR/EDR ATT connections when CONFIG_BT_ATT_OVER_BR is enabled.

## Testing
Build verified with CONFIG_BT_ATT_OVER_BR enabled.