### PR TITLE
Bluetooth: Host: Prevent duplicate ACL connection reply

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2562,6 +2562,11 @@ int bt_conn_accept_acl_conn(struct bt_conn *conn)
 {
 	int err;
 
+	if (atomic_test_and_set_bit(conn->flags, BT_CONN_BR_ACL_REPLIED)) {
+		LOG_WRN("ACL conn already replied");
+		return -EALREADY;
+	}
+
 	err = bt_accept_conn(conn->hdev, &conn->br.dst);
 	if (err) {
 		bt_conn_unref(conn);
@@ -2577,6 +2582,11 @@ int bt_conn_accept_acl_conn(struct bt_conn *conn)
 
 int bt_conn_reject_acl_conn(struct bt_conn *conn, uint8_t reason)
 {
+	if (atomic_test_and_set_bit(conn->flags, BT_CONN_BR_ACL_REPLIED)) {
+		LOG_WRN("ACL conn already replied");
+		return -EALREADY;
+	}
+
 	bt_reject_conn(conn->hdev, &conn->br.dst, reason);
 	bt_conn_unref(conn);
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -87,6 +87,8 @@ enum {
 	BT_CONN_CTE_REQ_ENABLED,              /* CTE request procedure is enabled */
 	BT_CONN_CTE_RSP_ENABLED,              /* CTE response procedure is enabled */
 
+	BT_CONN_BR_ACL_REPLIED,               /* ACL conn req already replied */
+
 	/* Total number of flags - must be at the end of the enum */
 	BT_CONN_NUM_FLAGS,
 };


### PR DESCRIPTION
bug: v/81923

When multiple apps register connect_req callback, each app may call bt_conn_accept_acl_conn or bt_conn_reject_acl_conn for the same incoming connection. This causes duplicate HCI commands to the controller.

Add BT_CONN_BR_ACL_REPLIED atomic flag to ensure only the first reply is honored. Subsequent replies return 0 immediately.