### PR TITLE
Bluetooth: HFP AG: clear stale codec negotiation state on AT+BCC

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2673,6 +2673,13 @@ static int bt_hfp_ag_bcc_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 	}
 	hfp_ag_unlock(ag);
 
+	/* Clear stale codec connection state from previous incomplete negotiation.
+	 * HF sending AT+BCC means it wants to (re)start audio connection,
+	 * so any pending codec negotiation should be reset. */
+	if (atomic_test_and_clear_bit(ag->flags, BT_HFP_AG_CODEC_CONN)) {
+		LOG_WRN("Cleared stale CODEC_CONN flag on AT+BCC");
+	}
+
 	if (bt_ag && bt_ag->audio_connect_req) {
 		bt_ag->audio_connect_req(ag);
 		return 0;


### PR DESCRIPTION
bug: v/88081

Rootcause: When HF does not reply AT+BCS during SLC setup, the BT_HFP_AG_CODEC_CONN flag remains set. When HF later sends AT+BCC to request audio connection, bt_hfp_ag_audio_connect() returns -EBUSY because CODEC_CONN is still set, preventing eSCO establishment.

Fix: In bt_hfp_ag_bcc_handler(), clear the stale BT_HFP_AG_CODEC_CONN flag so that audio connection can proceed when HF sends AT+BCC.



