### PR TITLE
bluetooth/rfcomm: fix null session crash in dlc rtx timeout

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -496,6 +496,11 @@ static void rfcomm_dlc_rtx_timeout(struct k_work *work)
 	struct bt_rfcomm_dlc *dlc = DLC_RTX(work);
 	struct bt_rfcomm_session *session = dlc->session;
 
+	if (!session) {
+		LOG_WRN("dlc %p timeout but session already gone", dlc);
+		return;
+	}
+
 	LOG_WRN("dlc %p state %d timeout", dlc, dlc->state);
 
 	rfcomm_dlcs_remove_dlci(session->dlcs, dlc->dlci);


### PR DESCRIPTION
bug: v/88179

rootcause: rfcomm_dlc_rtx_timeout accesses dlc->session which can be NULL when L2CAP disconnection races with the delayed work execution. rfcomm_dlc_destroy uses k_work_cancel_delayable (non-sync) to cancel the timer, but if the work is already queued in sysworkq, the cancel fails silently. The subsequent timeout callback dereferences the NULL session pointer at offset 0x130 (dlcs field), causing a Bus Fault. Using k_work_cancel_delayable_sync is not an option because both the destroy path and the rtx_work run on the same sysworkq, which would deadlock. Add a NULL check for session at the top of the timeout callback as a safe guard.

