### PR TITLE
bluetooth: sdp: Fix wdog list corruption in bt_sdp_disconnected

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -183,10 +183,22 @@ static void bt_sdp_disconnected(struct bt_l2cap_chan *chan)
 						   chan);
 
 	struct bt_sdp *sdp = CONTAINER_OF(ch, struct bt_sdp, chan);
+	struct net_buf *buf;
 
 	LOG_DBG("chan %p cid 0x%04x", ch, ch->tx.cid);
 
-	(void)memset(sdp, 0, sizeof(*sdp));
+	/*
+	 * Only reset SDP specific members, preserve the L2CAP channel
+	 * structure so that bt_l2cap_chan_del() can properly invoke
+	 * chan->destroy (l2cap_br_chan_destroy) to cancel rtx_work
+	 * and remove the wdog from g_wdactivelist.
+	 */
+	while ((buf = net_buf_get(&sdp->partial_resp_queue, K_NO_WAIT))) {
+		net_buf_unref(buf);
+	}
+
+	(void)memset(&sdp->partial_resp_queue, 0,
+		     sizeof(sdp->partial_resp_queue));
 }
 
 /* @brief Creates an SDP PDU


### PR DESCRIPTION
bug: v/88179

rootcause: bt_sdp_disconnected() calls memset(sdp, 0, sizeof(*sdp)) which zeroes the entire bt_sdp structure including the L2CAP channel member. Since bt_l2cap_chan_del() calls ops->disconnected before chan->destroy, this memset clears chan->destroy pointer (l2cap_br_chan_destroy) and the rtx_work wdog state. As a result, l2cap_br_chan_destroy is never called, k_work_cancel_delayable_sync is skipped, and the wdog node remains in g_wdactivelist with zeroed next/prev pointers. Any subsequent wd_insert traversal hits the corrupted node and triggers a Bus Fault at BFAR=0x00000010 (NULL->expired).

Fix by only clearing SDP-specific members (partial_resp_queue) and preserving the L2CAP channel structure, consistent with the approach used in sdp_client_disconnected().

Also drain all net_buf from partial_resp_queue before memset to prevent memory leak when the queue is non-empty at disconnect time.