### PR TITLE
Bluetooth: Classic: AVDTP: Fix null pointer crash when sending cmd on…

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -1699,6 +1699,12 @@ static int avdtp_send_cmd(struct bt_avdtp *session, struct net_buf *buf, struct 
 	/* From all the calls, the session, buf and req can't be NULL. */
 	__ASSERT_NO_MSG((session != NULL && buf != NULL && req != NULL));
 
+	if (session->br_chan.chan.conn == NULL) {
+		LOG_WRN("Session disconnected, cannot send cmd");
+		net_buf_unref(buf);
+		return -ENOTCONN;
+	}
+
 	avdtp_lock(session);
 
 	if (session->req != NULL) {


### PR DESCRIPTION
… disconnected session

bug: v/88933

When L2CAP disconnects during an ongoing GetAllCapabilities request, bt_avdtp_l2cap_disconnected sets session->br_chan.chan.conn to NULL and invokes the pending request callback with BAD_STATE. The callback chain (bt_a2dp_get_capabilities_cb -> bt_a2dp_discover_endpoint_cb) interprets info==NULL as discover-complete and proceeds to call set_configuration, which calls avdtp_send_cmd. avdtp_send_cmd then attempts to schedule timeout_work via k_work_reschedule, hitting a null pointer dereference in wd_start because the underlying connection resources are already freed.

Add a connection validity check at the entry of avdtp_send_cmd to return -ENOTCONN if session->br_chan.chan.conn is NULL, preventing any command from being sent on a disconnected session.

