### PR TITLE
bluetooth: host: add bt_probe trace probe instrumentation

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -27,6 +27,8 @@
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 
+#include "bt_probe_rfcomm.h"
+
 #define LOG_LEVEL CONFIG_BT_RFCOMM_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_rfcomm);
@@ -601,6 +603,9 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 			net_buf_unref(buf);
 			break;
 		}
+
+		bt_probe_rfcomm_tx(buf->data, buf->len,
+			(uint8_t)k_sem_count_get(&dlc->tx_credits));
 
 		if (rfcomm_send_cb(dlc->session, buf, rfcomm_sent, dlc) < 0) {
 			/* This fails only if channel is disconnected */
@@ -1432,13 +1437,21 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 		return;
 	}
 
+	uint8_t peer_credits_given = 0;
+
 	if (pf == BT_RFCOMM_PF_UIH_CREDIT) {
 		if (buf->len == 0) {
 			LOG_WRN("Data recvd is invalid");
 			return;
 		}
+		peer_credits_given = buf->data[0];
 		rfcomm_dlc_tx_give_credits(dlc, net_buf_pull_u8(buf));
 	}
+
+	/* buf->len now = payload + FCS (or just FCS for credit-only) */
+	bt_probe_rfcomm_rx(dlci,
+		(buf->len > BT_RFCOMM_FCS_SIZE) ? (buf->len - BT_RFCOMM_FCS_SIZE) : 0,
+		(uint8_t)dlc->rx_credit, peer_credits_given);
 
 	if (buf->len > BT_RFCOMM_FCS_SIZE) {
 		if (dlc->session->cfc == BT_RFCOMM_CFC_SUPPORTED &&

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -46,6 +46,8 @@
 #include "direction_internal.h"
 #include "classic/sco_internal.h"
 
+#include "bt_probe_hci.h"
+
 #define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_conn);
@@ -563,6 +565,9 @@ static int send_acl(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 
 	bt_buf_set_type(buf, BT_BUF_ACL_OUT);
+
+	bt_probe_hci_stack_tx_acl(buf->data, buf->len,
+		(uint8_t)k_sem_count_get(bt_conn_get_pkts(conn)));
 
 	return bt_send(conn->hdev, buf);
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -67,6 +67,8 @@
 #include "direction_internal.h"
 #endif /* CONFIG_BT_DF */
 
+#include "bt_probe_hci.h"
+
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_core);
@@ -654,6 +656,9 @@ static void hci_num_completed_packets(struct bt_dev *hdev, struct net_buf *buf)
 			continue;
 		}
 
+		bt_probe_hci_nocp(handle, count,
+			(uint16_t)k_sem_count_get(bt_conn_get_pkts(conn)));
+
 		while (count--) {
 			sys_snode_t *node;
 
@@ -699,6 +704,8 @@ static void hci_acl(struct bt_dev *hdev, struct net_buf *buf)
 		net_buf_unref(buf);
 		return;
 	}
+
+	bt_probe_hci_stack_rx_acl(buf->data, buf->len);
 
 	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 	len = sys_le16_to_cpu(hdr->len);


### PR DESCRIPTION
Add lightweight trace probe calls to HCI and RFCOMM protocol layers for cross-layer SPP throughput and latency analysis.

## HCI probes (conn.c, hci_core.c)
- bt_probe_hci_stack_tx_acl: before bt_send in send_acl()
- bt_probe_hci_stack_rx_acl: before header pull in hci_acl()
- bt_probe_hci_nocp: before NOCP while loop, captures handle, count, acl_quota

## RFCOMM probes (rfcomm.c)
- bt_probe_rfcomm_tx: before rfcomm_send_cb, captures raw frame and peer credits
- bt_probe_rfcomm_rx: after credit processing, captures dlci, payload length, credits

## Related PRs
- open-vela/frameworks_bluetooth#574: trace infrastructure and SPP probe definitions