### PR TITLE
bluetooth: fix GCC 13 build errors for best1700_ep

### DIFF
--- a/port/kernel/poll.c
+++ b/port/kernel/poll.c
@@ -65,7 +65,7 @@ static inline bool is_condition_met(struct k_poll_event *event, uint32_t *state)
 }
 
 /* must be called with interrupts locked */
-static inline void register_event(struct k_poll_event *event,
+static __attribute__((noinline)) void register_event(struct k_poll_event *event,
 				 struct z_poller *poller)
 {
 	switch (event->type) {

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3428,7 +3428,7 @@ static int bt_hfp_ag_binp_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 static int bt_hfp_ag_vts_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 {
 	int err;
-	char code;
+	char code = '\0';
 
 	if (!is_char(buf, '=')) {
 		return -ENOTSUP;


### PR DESCRIPTION
bug: v/88813

Fix two -Werror build failures when compiling zblue with GCC 13+ toolchain (cortex-m55/armv8.1-m):

1. poll.c: mark register_event as noinline to prevent GCC from detecting a false-positive dangling-pointer when the function is inlined into k_poll(). The stack-local poller variable is guaranteed to outlive all references since every exit path in k_poll() calls clear_event_registrations() which sets event->poller to NULL.

2. hfp_ag.c: initialize local variable 'code' to silence maybe-uninitialized warning. The variable is always assigned by get_char() before use, but GCC cannot prove this statically.

GCC 13 introduces -Wdangling-pointer which fires when an inlined function stores a stack variable address into an external pointer. GCC 13 also has stricter -Wmaybe-uninitialized analysis that cannot track initialization through output parameters across conditional branches.


