### PR TITLE
fix: add missing headers to resolve LTO type mismatch errors

### DIFF
--- a/port/kernel/mem_slab.c
+++ b/port/kernel/mem_slab.c
@@ -19,6 +19,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/check.h>
+#include <ksched.h>
 
 static struct k_spinlock lock;
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -30,6 +30,7 @@
 #include "did_internal.h"
 #include "rfcomm_internal.h"
 #include "sdp_internal.h"
+#include "host/smp.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_l2cap_br, CONFIG_BT_L2CAP_LOG_LEVEL);


### PR DESCRIPTION
bug: v/89211

Include <ksched.h> in mem_slab.c and "host/smp.h" in l2cap_br.c to provide correct bool return type declarations for z_sched_wake() and bt_smp_ctkd_br_to_le_enabled(), fixing -Werror=lto-type-mismatch.

