### PR TITLE
bluetooth: net_buf: add CONFIG_NET_BUF_HEAP_DATA support for dynamic …

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1144,6 +1144,7 @@ struct net_buf_pool {
 	static struct _net_buf_##_name _net_buf_##_name[_count] __noinit
 
 extern const struct net_buf_data_alloc net_buf_heap_alloc;
+extern const struct net_buf_data_cb net_buf_heap_cb;
 /** @endcond */
 
 /**
@@ -1218,6 +1219,10 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  * @param _ud_size   User data space to reserve per buffer.
  * @param _destroy   Optional destroy callback when buffer is freed.
  */
+#ifdef CONFIG_NET_BUF_ALWAYS_USE_HEAP
+#define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
+	NET_BUF_POOL_DEFINE(_name, _count, _data_size, _ud_size, _destroy)
+#else
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
 	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
@@ -1233,6 +1238,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_fixed_alloc_##_name,  \
 					 _net_buf_##_name, _count, _ud_size,   \
 					 _destroy)
+#endif
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct net_buf_data_cb net_buf_var_cb;
@@ -1296,8 +1302,21 @@ extern const struct net_buf_data_cb net_buf_var_cb;
  * @param _ud_size  Amount of user data space to reserve.
  * @param _destroy  Optional destroy callback when buffer is freed.
  */
+#ifdef CONFIG_NET_BUF_ALWAYS_USE_HEAP
+#define NET_BUF_POOL_DEFINE(_name, _count, _size, _ud_size, _destroy)        \
+	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                      \
+	static const struct net_buf_data_alloc net_buf_heap_alloc_##_name = { \
+		.cb = &net_buf_heap_cb,                                       \
+		.max_alloc_size = _size,                                      \
+	};                                                                    \
+	static STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                \
+		NET_BUF_POOL_INITIALIZER(_name, &net_buf_heap_alloc_##_name, \
+					 _net_buf_##_name, _count, _ud_size, \
+					 _destroy)
+#else
 #define NET_BUF_POOL_DEFINE(_name, _count, _size, _ud_size, _destroy)        \
 	NET_BUF_POOL_FIXED_DEFINE(_name, _count, _size, _ud_size, _destroy)
+#endif
 
 /**
  * @brief Looks up a pool based on its ID.

--- a/lib/net_buf/Kconfig
+++ b/lib/net_buf/Kconfig
@@ -59,4 +59,12 @@ config NET_BUF_ALIGNMENT
 	  Default value of 0 means the alignment will be the size of a void pointer,
 	  any other value will force the alignment of a net buffer in bytes.
 
+config NET_BUF_ALWAYS_USE_HEAP
+	bool "Always use heap allocation for net_buf data"
+	help
+	  When enabled, NET_BUF_POOL_DEFINE and NET_BUF_POOL_FIXED_DEFINE
+	  will use heap-based dynamic allocation (malloc/k_malloc) instead
+	  of fixed-size static arrays for buffer data payloads. This can
+	  save memory when buffers are not always fully utilized.
+
 endif # NET_BUF

--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -166,7 +166,7 @@ const struct net_buf_data_cb net_buf_fixed_cb = {
 	.unref = fixed_data_unref,
 };
 
-#if (K_HEAP_MEM_POOL_SIZE > 0)
+#if (K_HEAP_MEM_POOL_SIZE > 0) || defined(CONFIG_NET_BUF_ALWAYS_USE_HEAP)
 
 static uint8_t *heap_data_alloc(struct net_buf *buf, size_t *size,
 			     k_timeout_t timeout)
@@ -195,7 +195,7 @@ static void heap_data_unref(struct net_buf *buf, uint8_t *data)
 	k_free(ref_count);
 }
 
-static const struct net_buf_data_cb net_buf_heap_cb = {
+const struct net_buf_data_cb net_buf_heap_cb = {
 	.alloc = heap_data_alloc,
 	.ref   = generic_data_ref,
 	.unref = heap_data_unref,
@@ -206,7 +206,7 @@ const struct net_buf_data_alloc net_buf_heap_alloc = {
 	.max_alloc_size = 0,
 };
 
-#endif /* K_HEAP_MEM_POOL_SIZE > 0 */
+#endif /* K_HEAP_MEM_POOL_SIZE > 0 || CONFIG_NET_BUF_ALWAYS_USE_HEAP */
 
 static uint8_t *data_alloc(struct net_buf *buf, size_t *size, k_timeout_t timeout)
 {

--- a/port/include/zephyr/net_buf.h
+++ b/port/include/zephyr/net_buf.h
@@ -1144,6 +1144,7 @@ struct net_buf_pool {
 	static struct _net_buf_##_name _net_buf_##_name[_count] __noinit
 
 extern const struct net_buf_data_alloc net_buf_heap_alloc;
+extern const struct net_buf_data_cb net_buf_heap_cb;
 /** @endcond */
 
 /**
@@ -1175,7 +1176,7 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
  */
 #define NET_BUF_POOL_HEAP_DEFINE(_name, _count, _ud_size, _destroy)          \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                      \
-	static STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                \
+	STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                       \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_heap_alloc,         \
 					 _net_buf_##_name, _count, _ud_size, \
 					 _destroy)
@@ -1218,6 +1219,10 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  * @param _ud_size   User data space to reserve per buffer.
  * @param _destroy   Optional destroy callback when buffer is freed.
  */
+#ifdef CONFIG_NET_BUF_ALWAYS_USE_HEAP
+#define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
+	NET_BUF_POOL_DEFINE(_name, _count, _data_size, _ud_size, _destroy)
+#else
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
 	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
@@ -1229,10 +1234,11 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 		.alloc_data = (void *)&net_buf_fixed_##_name,                  \
 		.max_alloc_size = _data_size,                                  \
 	};                                                                     \
-	STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                  \
+	STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                         \
 		NET_BUF_POOL_INITIALIZER(_name, &net_buf_fixed_alloc_##_name,  \
 					 _net_buf_##_name, _count, _ud_size,   \
 					 _destroy)
+#endif
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct net_buf_data_cb net_buf_var_cb;
@@ -1296,8 +1302,21 @@ extern const struct net_buf_data_cb net_buf_var_cb;
  * @param _ud_size  Amount of user data space to reserve.
  * @param _destroy  Optional destroy callback when buffer is freed.
  */
+#ifdef CONFIG_NET_BUF_ALWAYS_USE_HEAP
+#define NET_BUF_POOL_DEFINE(_name, _count, _size, _ud_size, _destroy)        \
+	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                      \
+	static const struct net_buf_data_alloc net_buf_heap_alloc_##_name = { \
+		.cb = &net_buf_heap_cb,                                       \
+		.max_alloc_size = _size,                                      \
+	};                                                                    \
+	STRUCT_SECTION_ITERABLE(net_buf_pool, _name) =                       \
+		NET_BUF_POOL_INITIALIZER(_name, &net_buf_heap_alloc_##_name, \
+					 _net_buf_##_name, _count, _ud_size, \
+					 _destroy)
+#else
 #define NET_BUF_POOL_DEFINE(_name, _count, _size, _ud_size, _destroy)        \
 	NET_BUF_POOL_FIXED_DEFINE(_name, _count, _size, _ud_size, _destroy)
+#endif
 
 /**
  * @brief Looks up a pool based on its ID.

--- a/port/lib/net_buf/buf.c
+++ b/port/lib/net_buf/buf.c
@@ -199,14 +199,24 @@ const struct net_buf_data_cb net_buf_fixed_cb = {
 	.unref = fixed_data_unref,
 };
 
-#if (K_HEAP_MEM_POOL_SIZE > 0)
+#if (K_HEAP_MEM_POOL_SIZE > 0) || defined(CONFIG_NET_BUF_ALWAYS_USE_HEAP)
+
+static uint8_t *generic_data_ref(struct net_buf *buf, uint8_t *data)
+{
+	uint8_t *ref_count;
+
+	ref_count = data - sizeof(void *);
+	(*ref_count)++;
+
+	return data;
+}
 
 static uint8_t *heap_data_alloc(struct net_buf *buf, size_t *size,
 			     k_timeout_t timeout)
 {
 	uint8_t *ref_count;
 
-	ref_count = k_malloc(sizeof(void *) + *size);
+	ref_count = malloc(sizeof(void *) + *size);
 	if (!ref_count) {
 		return NULL;
 	}
@@ -225,10 +235,10 @@ static void heap_data_unref(struct net_buf *buf, uint8_t *data)
 		return;
 	}
 
-	k_free(ref_count);
+	free(ref_count);
 }
 
-static const struct net_buf_data_cb net_buf_heap_cb = {
+const struct net_buf_data_cb net_buf_heap_cb = {
 	.alloc = heap_data_alloc,
 	.ref   = generic_data_ref,
 	.unref = heap_data_unref,
@@ -239,7 +249,7 @@ const struct net_buf_data_alloc net_buf_heap_alloc = {
 	.max_alloc_size = 0,
 };
 
-#endif /* K_HEAP_MEM_POOL_SIZE > 0 */
+#endif /* K_HEAP_MEM_POOL_SIZE > 0 || CONFIG_NET_BUF_ALWAYS_USE_HEAP */
 
 static uint8_t *data_alloc(struct net_buf *buf, size_t *size, k_timeout_t timeout)
 {


### PR DESCRIPTION
…buffer allocation

bug: v/89579

Add CONFIG_NET_BUF_HEAP_DATA Kconfig option to control net_buf data allocation strategy. When enabled, NET_BUF_POOL_DEFINE and NET_BUF_POOL_FIXED_DEFINE use heap-based dynamic allocation instead of fixed-size static arrays for buffer data payloads.

Key changes:
- Add NET_BUF_HEAP_DATA Kconfig option in lib/net_buf/Kconfig
- Export net_buf_heap_cb for use by macro-expanded pool definitions
- Add conditional compilation in net_buf.h: when enabled, both NET_BUF_POOL_DEFINE and NET_BUF_POOL_FIXED_DEFINE use heap path
- No .c call-site changes needed, all handled via macros

Enabling this option saves ~80KB static RAM (BSS) on test platform.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

