### PR TITLE
bluetooth: fix ATT and Kconfig dependency for non-default configurations

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -168,6 +168,7 @@ source "$APPSDIR/external/zblue/zblue/subsys/bluetooth/audio/Kconfig"
 config BT_HOST_CRYPTO
 	bool "Use crypto functionality implemented in the Bluetooth host"
 	default y if !BT_CTLR_CRYPTO
+	select CRYPTO_MBEDTLS if !BUILD_WITH_TFM
 	select MBEDTLS if !BUILD_WITH_TFM
 	select MBEDTLS_PSA_CRYPTO_C if !BUILD_WITH_TFM
 	select PSA_WANT_KEY_TYPE_AES

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3362,7 +3362,9 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 
 		conn = br_chan->chan.conn;
 		/* ATT over BR negotiates MTU via L2CAP configuration. */
+#if defined(CONFIG_BT_GATT_CLIENT)
 		atomic_set_bit(chan->conn->flags, BT_CONN_ATT_MTU_EXCHANGED);
+#endif
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&chan->conn->hdev->att_ctx->conn_cbs, callback, _node) {
 			if (callback->connected) {


### PR DESCRIPTION
## Summary
- Add CONFIG_BT_GATT_CLIENT guard for ATT over BR MTU flag in att.c (v/90624)
- Add CRYPTO_MBEDTLS dependency to BT_HOST_CRYPTO for BLE-only builds (v/90636)

## Test plan
- [x] Base config (goldfish-armeabi-v7a-ap) builds successfully
- [x] BLE-only configuration passes Kconfig dependency resolution
- [x] BREDR-only configuration compiles without ATT undeclared errors

## Related JIRAs
v/90624, v/90636

Signed-off-by: huangyulong3 <huangyulong3@xiaomi.com>