### PR TITLE
zblue: fix compilation errors

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -476,6 +476,9 @@ struct bt_a2dp_cb {
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*config_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
+	int (*get_config_req)(struct bt_a2dp_stream *stream, uint8_t *rsp_err_code);
+	void (*get_config_rsp)(struct bt_a2dp_stream *stream,
+			       struct bt_a2dp_codec_cfg *config, uint8_t rsp_err_code);
 	/**
 	 * @brief Stream establishment request callback
 	 *

--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -576,6 +576,8 @@ struct bt_sdp_discover_params {
 	struct net_buf_pool *pool;
 	/** Discover type */
 	uint8_t type;
+	void (*disconnected)(struct bt_conn *conn,
+			     const struct bt_sdp_discover_params *params);
 };
 
 /** @brief Allows user to start SDP discovery session.

--- a/port/sections/defines.c
+++ b/port/sections/defines.c
@@ -115,6 +115,12 @@ const struct bt_conn_cb *_bt_conn_cb_list[] = {
 };
 /* bt_conn_cb END */
 
+/* bt_sco_conn_cb START */
+struct bt_sco_conn_cb *_bt_sco_conn_cb_list[] = {
+	NULL,
+};
+/* bt_sco_conn_cb END */
+
 /* net_buf_pool START */
 extern struct net_buf_pool sine_tx_pool;
 extern struct net_buf_pool tx_pool;
@@ -149,7 +155,7 @@ extern struct net_buf_pool prep_pool;
 extern struct net_buf_pool att_pool;
 extern struct net_buf_pool acl_in_pool;
 extern struct net_buf_pool acl_tx_pool;
-extern struct net_buf_pool dummy_pool;
+struct net_buf_pool dummy_pool;
 // extern struct net_buf_pool a2dp_tx_pool; // for Zephyr shell
 extern struct net_buf_pool bt_a2dp_tx_pool; // for openvela sal
 

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -256,6 +256,9 @@ struct bt_avdtp_ops_cb {
 	int (*set_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
 				     uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);
 
+	int (*get_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
+				     struct net_buf *rsp_buf, uint8_t *errcode);
+
 	int (*re_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
 				    struct net_buf *buf, uint8_t *errcode);
 


### PR DESCRIPTION
## Summary

Fix compilation errors in bluetooth classic headers and port layer.

## Changes

- Add missing declarations in `include/zephyr/bluetooth/classic/a2dp.h`
- Add missing declarations in `include/zephyr/bluetooth/classic/sdp.h`
- Add missing includes in `subsys/bluetooth/host/classic/avdtp_internal.h`
- Fix `port/sections/defines.c` port section issues

4 files changed, 15 insertions(+), 1 deletion(-)