### PR TITLE
bluetooth: avrcp: fix label/case followed by declaration in notificat…

### DIFF
--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -1154,7 +1154,7 @@ static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid
 			return BT_AVRCP_STATUS_INVALID_PARAMETER;
 		}
 		break;
-	case BT_AVRCP_EVT_TRACK_CHANGED:
+	case BT_AVRCP_EVT_TRACK_CHANGED: {
 		if (buf->len < sizeof(event_data->identifier)) {
 			LOG_ERR("Invalid TRACK_CHANGED response length");
 			return BT_AVRCP_STATUS_INVALID_PARAMETER;
@@ -1163,6 +1163,7 @@ static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid
 
 		memcpy(event_data->identifier, &identifier, sizeof(uint64_t));
 		break;
+	}
 	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
 		if (buf->len < sizeof(event_data->playback_pos)) {
 			LOG_ERR("Invalid PLAYBACK_POS_CHANGED response length");
@@ -1268,23 +1269,29 @@ static int process_register_notification_rsp(struct bt_avrcp *avrcp, uint8_t tid
 	}
 	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 notify_callback:
-	/* Find the event registered with this TID and clear ONLY that one */
-	uint8_t failed_evt = 0;
-	bool found = false;
+	/* Find the event registered with this TID and clear ONLY that one.
+	 * The braces here form a compound statement so the label is followed
+	 * by a statement (C forbids a declaration directly after a label).
+	 */
+	{
+		uint8_t failed_evt = 0;
+		bool found = false;
 
-	ARRAY_FOR_EACH(ct->ct_notify, i) {
-		if (ct->ct_notify[i].tid == tid && ct->ct_notify[i].cb != NULL) {
-			failed_evt = i;
-			ct->ct_notify[i].cb = NULL;
-			ct->ct_notify[i].interim_received = 0;
-			found = true;
-			break;
+		ARRAY_FOR_EACH(ct->ct_notify, i) {
+			if (ct->ct_notify[i].tid == tid && ct->ct_notify[i].cb != NULL) {
+				failed_evt = i;
+				ct->ct_notify[i].cb = NULL;
+				ct->ct_notify[i].interim_received = 0;
+				found = true;
+				break;
+			}
 		}
+
+		avrcp_ct_cb->notification(get_avrcp_ct(avrcp), tid, status,
+					  found ? failed_evt : 0, NULL);
+
+		return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 	}
-
-	avrcp_ct_cb->notification(get_avrcp_ct(avrcp), tid, status, found ? failed_evt : 0, NULL);
-
-	return BT_AVRCP_STATUS_OPERATION_COMPLETED;
 }
 
 static int process_set_absolute_volume_rsp(struct bt_avrcp *avrcp, uint8_t tid,
@@ -4331,11 +4338,12 @@ static int build_notification_rsp_data(uint8_t event_id, struct bt_avrcp_event_d
 		}
 		net_buf_add_u8(buf, data->play_status);
 		break;
-	case BT_AVRCP_EVT_TRACK_CHANGED:
+	case BT_AVRCP_EVT_TRACK_CHANGED: {
 		uint64_t identifier = sys_get_be64(data->identifier);
 
 		net_buf_add_be64(buf, identifier);
 		break;
+	}
 	case BT_AVRCP_EVT_PLAYBACK_POS_CHANGED:
 		net_buf_add_be32(buf, data->playback_pos);
 		break;


### PR DESCRIPTION
…ion rsp

bug: v/90707

In process_register_notification_rsp() and build_notification_rsp_data(), a declaration immediately followed a goto label and a switch case label. C forbids a declaration directly after a label, which triggered static analysis errors (ERR_EXPECTED_EXPRESSION and ERR_UNDECLARED_VAR_USE for failed_evt / identifier) and is technically ill-formed pre-C23.

Wrap the affected sections in compound statements so the labels are followed by statements rather than declarations. No functional change.


