### PR TITLE
Delivery/esp32s3 eye safe 20260904

### DIFF
--- a/include/zephyr/bluetooth/classic/hid_device.h
+++ b/include/zephyr/bluetooth/classic/hid_device.h
@@ -84,9 +84,9 @@ struct bt_hid_device_cb {
 	/**
 	 * @brief HID Device Connected Callback
 	 *
-	 * The callback is called whenever an hid device connected.
+	 * The callback is called whenever an HID device connected.
 	 *
-	 *  @param hid hid device connection object.
+	 *  @param hid HID device connection object.
 	 *
 	 */
 	void (*connected)(struct bt_hid_device *hid);
@@ -94,44 +94,54 @@ struct bt_hid_device_cb {
 	/**
 	 * @brief HID Device Disconected Callback
 	 *
-	 * The callback is called whenever an hid device disconnected.
+	 * The callback is called whenever an HID device disconnected.
 	 *
-	 *  @param hid hid device connection object.
+	 *  @param hid HID device connection object.
 	 *
 	 */
 	void (*disconnected)(struct bt_hid_device *hid);
 
 	/**
-	 * @brief HID Device Set Report Callback
+	 * @brief HID Device Accept Callback
 	 *
-	 *  An hid device set report request from remote.
+	 *  An HID device connection accept from remote.
 	 *
-	 *  @param hid hid device connection object.
-	 *  @param data value.
-	 *  @param data len.
+	 *  @param hid HID device connection object.
 	 *
 	 */
-	void (*set_report)(struct bt_hid_device *hid, uint8_t *data, uint16_t len);
+	void (*accept)(struct bt_hid_device *hid);
+
+	/**
+	 * @brief HID Device Set Report Callback
+	 *
+	 *  An HID device set report request from remote.
+	 *
+	 *  @param hid HID device connection object.
+	 *  @param data Value.
+	 *  @param len  Len.
+	 *
+	 */
+	void (*set_report)(struct bt_hid_device *hid, const uint8_t *data, uint16_t len);
 
 	/**
 	 * @brief HID Device Get Report Callback
 	 *
-	 *  An hid device get report request from remote.
+	 *  An HID device get report request from remote.
 	 *
-	 *  @param hid hid device connection object.
-	 *  @param data value.
-	 *  @param data len.
+	 *  @param hid HID device connection object.
+	 *  @param data Value.
+	 *  @param len Len.
 	 *
 	 */
-	void (*get_report)(struct bt_hid_device *hid, uint8_t *data, uint16_t len);
+	void (*get_report)(struct bt_hid_device *hid, const uint8_t *data, uint16_t len);
 
 	/**
 	 * @brief HID Device Set Protocol Callback
 	 *
-	 *  An hid device set protocol request from remote.
+	 *  An HID device set protocol request from remote.
 	 *
-	 *  @param hid hid device connection object.
-	 *  @param protocol protocol.
+	 *  @param hid HID device connection object.
+	 *  @param protocol Protocol.
 	 *
 	 */
 	void (*set_protocol)(struct bt_hid_device *hid, uint8_t protocol);
@@ -139,9 +149,9 @@ struct bt_hid_device_cb {
 	/**
 	 * @brief HID Device Get Protocol Callback
 	 *
-	 *  An hid device get protocol request from remote.
+	 *  An HID device get protocol request from remote.
 	 *
-	 *  @param hid hid device connection object.
+	 *  @param hid HID device connection object.
 	 *
 	 */
 	void (*get_protocol)(struct bt_hid_device *hid);
@@ -149,11 +159,11 @@ struct bt_hid_device_cb {
 	/**
 	 * @brief HID Device Intr data Callback
 	 *
-	 *  An hid device intr data request from remote.
+	 *  An HID device intr data request from remote.
 	 *
-	 *  @param hid hid device connection object.
-	 *  @param data value.
-	 *  @param data len.
+	 *  @param hid HID device connection object.
+	 *  @param data Value.
+	 *  @param len  Len.
 	 *
 	 */
 	void (*intr_data)(struct bt_hid_device *hid, uint8_t *data, uint16_t len);
@@ -161,9 +171,9 @@ struct bt_hid_device_cb {
 	/**
 	 * @brief HID Device Unplug Callback
 	 *
-	 *  An hid device unplug request from remote.
+	 *  An HID device unplug request from remote.
 	 *
-	 *  @param hid hid device connection object.
+	 *  @param hid HID device connection object.
 	 *
 	 */
 	void (*vc_unplug)(struct bt_hid_device *hid);
@@ -175,9 +185,9 @@ struct bt_hid_device_cb {
  *
  *  @param cb The callback function.
  *
- *  @return 0 in case of success and error code in case of error.
+ *  @return 0 In case of success and error code in case of error.
  */
-int bt_hid_device_register(struct bt_hid_device_cb *cb);
+int Z_API(bt_hid_device_register)(struct bt_hid_device_cb *cb);
 
 /** @brief HID Device Connect.
  *
@@ -187,59 +197,69 @@ int bt_hid_device_register(struct bt_hid_device_cb *cb);
  *
  *  @param conn Pointer to bt_conn structure.
  *
- *  @return pointer to struct bt_hid_device in case of success or NULL in case
+ *  @return Pointer to struct bt_hid_device in case of success or NULL in case
  *  of error.
  */
-struct bt_hid_device *bt_hid_device_connect(struct bt_conn *conn);
+struct bt_hid_device *Z_API(bt_hid_device_connect)(struct bt_conn *conn);
 
 /** @brief HID Device Disconnect
  *
  * This function close HID Device connection.
  *
- *  @param hid The bt_hid_device instance.
+ *  @param hid HID device connection object.
  *
  *  @return 0 in case of success and error code in case of error.
  */
-int bt_hid_device_disconnect(struct bt_hid_device *hid);
+int Z_API(bt_hid_device_disconnect)(struct bt_hid_device *hid);
 
 /** @brief HID Device Send Ctrl Data.
  *
  *  Send hid data by ctrl channel.
  *
- *  @param hid The bt_hid_device instance.
+ *  @param hid HID device connection object.
  *  @param type HID report type.
- *  @param data send buffer.
- *  @param len buffer size.
+ *  @param data Send buffer.
+ *  @param len Buffer size.
  *
  *  @return size in case of success and error code in case of error.
  */
-int bt_hid_device_send_ctrl_data(struct bt_hid_device *hid, uint8_t type, uint8_t *data,
-				 uint16_t len);
+int Z_API(bt_hid_device_send_ctrl_data)(struct bt_hid_device *hid, uint8_t type,
+					const uint8_t *data, uint16_t len);
 
 /** @brief HID Device Send Intr Data.
  *
  *  Send hid data by Intr channel.
  *
- *  @param hid The bt_hid_device instance.
+ *  @param hid HID device connection object.
  *  @param type HID report type.
- *  @param data send buffer.
- *  @param len buffer size.
+ *  @param data Send buffer.
+ *  @param len Buffer size.
  *
  *  @return size in case of success and error code in case of error.
  */
-int bt_hid_device_send_intr_data(struct bt_hid_device *hid, uint8_t type, uint8_t *data,
-				 uint16_t len);
+int Z_API(bt_hid_device_send_intr_data)(struct bt_hid_device *hid, uint8_t type,
+					const uint8_t *data, uint16_t len);
 
 /** @brief HID Device Send Error Response.
  *
  *  Send hid error response by ctrl channel.
  *
- *  @param hid The bt_hid_device instance.
- *  @param error error code.
+ *  @param hid HID device connection object.
+ *  @param error Error code.
  *
  *  @return size in case of success and error code in case of error.
  */
-int bt_hid_device_report_error(struct bt_hid_device *hid, uint8_t error);
+int Z_API(bt_hid_device_report_error)(struct bt_hid_device *hid, uint8_t error);
+
+/** @brief HID Device Unplug.
+ *
+ * This function Unplug HID Device.
+ *
+ *  @param hid HID device connection object.
+ *
+ *  @return 0 in case of success and error code in case of error.
+ */
+int Z_API(bt_hid_device_virtual_unplug)(struct bt_hid_device *hid);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/classic/hid_device.h
+++ b/include/zephyr/bluetooth/classic/hid_device.h
@@ -19,6 +19,11 @@ extern "C" {
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
+#define BT_HID_DEVICE_API_PREFIXED 1
+#define BT_HID_DEVICE_API_HAS_ACCEPT 1
+#define BT_HID_DEVICE_API_CONST_REPORT 1
+#define BT_HID_DEVICE_API_HAS_VIRTUAL_UNPLUG 1
+
 #define BT_HID_MAX_MTU         64
 #define BT_HID_REPORT_DATA_LEN 64
 

--- a/subsys/bluetooth/host/classic/hid_device.c
+++ b/subsys/bluetooth/host/classic/hid_device.c
@@ -74,6 +74,260 @@ static enum bt_hid_session_role get_session_role_from_chan(struct bt_l2cap_chan 
 	return session->role;
 }
 
+static struct net_buf *hid_create_pdu(uint8_t type, uint8_t param)
+{
+	struct net_buf *buf;
+	struct bt_hid_header *hdr;
+
+	buf = bt_l2cap_create_pdu(NULL, sizeof(*hdr));
+	if (buf == NULL) {
+		LOG_ERR("Can't create buf buf for type:%d, param:%d", type, param);
+		return NULL;
+	}
+
+	hdr = net_buf_add(buf, sizeof(*hdr));
+	hdr->type = type;
+	hdr->param = param;
+
+	return buf;
+}
+
+static int hid_send_pdu(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	int err;
+
+	err = bt_l2cap_chan_send(chan, buf);
+	if (err < 0) {
+		LOG_ERR("L2CAP send fail, err:%d", err);
+		net_buf_unref(buf);
+		return err;
+	}
+
+	return err;
+}
+
+static int hid_send_data(struct bt_hid_session *session, uint8_t type,
+	const uint8_t *data, uint16_t len)
+{
+	struct net_buf *buf;
+
+	buf = hid_create_pdu(BT_HID_TYPE_DATA, type);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	if (len > 0) {
+		net_buf_add_mem(buf, data, len);
+	}
+
+	return hid_send_pdu(&session->br_chan.chan, buf);
+}
+
+static int hid_send_handshake(struct bt_hid_session *session, uint8_t response)
+{
+	struct net_buf *buf;
+
+	buf = hid_create_pdu(BT_HID_TYPE_HANDSHAKE, response);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	return hid_send_pdu(&session->br_chan.chan, buf);
+}
+
+static int hid_control_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t control)
+{
+	struct bt_hid_device *hid;
+	int err = 0;
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	switch (control) {
+	case BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG:
+		err = Z_API(bt_hid_device_disconnect)(hid);
+		hid->pending_vc_unplug = 1;
+		break;
+	case BT_HID_CONTROL_SUSPEND:
+		break;
+	case BT_HID_CONTROL_EXIT_SUSPEND:
+		break;
+	default:
+		LOG_ERR("HID control:%d not handle", control);
+		err = -EINVAL;
+		break;
+	}
+
+	return err;
+}
+
+static int hid_get_report_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_device *hid;
+	struct bt_hid_report report = {0};
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	if (buf->len > sizeof(report.data)) {
+		LOG_ERR("HID get report data length:%d exceeds maximum:%d", buf->len,
+			sizeof(report.data));
+		return -EINVAL;
+	}
+
+	memcpy(report.data, buf->data, buf->len);
+	report.type = param & HID_PAR_REPORT_TYPE_MASK;
+	report.len = buf->len;
+
+	if (hid_cb == NULL || hid_cb->get_report == NULL) {
+		LOG_ERR("HID get report callback not found");
+		return -ESRCH;
+	}
+
+	hid_cb->get_report(hid, (const uint8_t *)&report, sizeof(report));
+	return 0;
+}
+
+static int hid_set_report_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_device *hid;
+	struct bt_hid_report report = {0};
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	if (buf->len > sizeof(report.data)) {
+		LOG_ERR("HID set report data length:%d exceeds maximum:%d", buf->len,
+			sizeof(report.data));
+		return -EINVAL;
+	}
+
+	memcpy(report.data, buf->data, buf->len);
+	report.type = param & HID_PAR_REPORT_TYPE_MASK;
+	report.len = buf->len;
+
+	if (hid_cb == NULL || hid_cb->set_report == NULL) {
+		LOG_ERR("HID set report callback not found");
+		return -ESRCH;
+	}
+
+	hid_cb->set_report(hid, (const uint8_t *)&report, sizeof(report));
+	return 0;
+}
+
+static int hid_get_protocol_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_device *hid;
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	if (hid_cb == NULL || hid_cb->get_protocol == NULL) {
+		LOG_ERR("HID get protocol callback not found");
+		return -ESRCH;
+	}
+
+	hid_cb->get_protocol(hid);
+	return 0;
+}
+
+static int hid_set_protocol_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_device *hid;
+	struct bt_hid_session *session;
+	uint8_t protocol;
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	protocol = param & BT_HID_PROTOCOL_MASK;
+
+	if (hid_cb == NULL || hid_cb->set_protocol == NULL) {
+		LOG_ERR("HID set protocol callback not found");
+		return -ESRCH;
+	}
+
+	hid_cb->set_protocol(hid, protocol);
+	session = HID_SESSION_BY_CHAN(chan);
+
+	return hid_send_handshake(session, BT_HID_HANDSHAKE_RSP_SUCCESS);
+}
+
+static int hid_intr_handle(struct bt_l2cap_chan *chan, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_device *hid;
+	struct bt_hid_report report = {0};
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EINVAL;
+	}
+
+	hid = HID_DEVICE_BY_INTR_CHAN(chan);
+	if (hid == NULL) {
+		LOG_ERR("HID not found");
+		return -EIO;
+	}
+
+	if (buf->len > sizeof(report.data)) {
+		LOG_ERR("HID intr data length:%d exceeds maximum:%d", buf->len,
+			sizeof(report.data));
+		return -EINVAL;
+	}
+
+	report.type = param & HID_PAR_REPORT_TYPE_MASK;
+	report.len = buf->len;
+	memcpy(report.data, buf->data, buf->len);
+
+	if (hid_cb == NULL || hid_cb->intr_data == NULL) {
+		LOG_ERR("HID intr data callback not found");
+		return -ESRCH;
+	}
+
+	hid_cb->intr_data(hid, (uint8_t *)&report, sizeof(report));
+	return 0;
+}
+
 static void bt_hid_l2cap_ctrl_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_hid_device *hid;
@@ -101,6 +355,21 @@ static void bt_hid_l2cap_ctrl_connected(struct bt_l2cap_chan *chan)
 	}
 
 	hid->state = BT_HID_STATE_CTRL_CONNECTED;
+
+	if (hid->role == BT_HID_ROLE_ACCEPTOR) {
+		/* Wait for INTR channel connection from remote */
+		LOG_DBG("HID wait for INTR channel connection from remote");
+		return;
+	}
+
+	err = bt_l2cap_chan_connect(hid->conn, &hid->intr_session.br_chan.chan,
+				    BT_L2CAP_PSM_HID_INT);
+	if (err) {
+		LOG_ERR("HID connect INTR failed");
+		hid->state = BT_HID_STATE_DISCONNECTING;
+		bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+		return;
+	}
 }
 
 static void bt_hid_l2cap_intr_connected(struct bt_l2cap_chan *chan)
@@ -159,6 +428,24 @@ static void bt_hid_l2cap_ctrl_disconnected(struct bt_l2cap_chan *chan)
 		LOG_ERR("HID invalid role:%d", role);
 		return;
 	}
+
+	/* if INTR session connected, it need to be disconnected */
+	if (hid->intr_session.br_chan.chan.conn) {
+		LOG_DBG("HID disconnect INTR channel");
+		bt_l2cap_chan_disconnect(&hid->intr_session.br_chan.chan);
+		return;
+	}
+
+	if (hid->pending_vc_unplug && hid_cb && hid_cb->vc_unplug) {
+		hid_cb->vc_unplug(hid);
+		hid->pending_vc_unplug = 0;
+	}
+
+	if (hid_cb && hid_cb->disconnected) {
+		hid_cb->disconnected(hid);
+	}
+
+	bt_hid_deinit(hid);
 }
 
 static void bt_hid_l2cap_intr_disconnected(struct bt_l2cap_chan *chan)
@@ -186,6 +473,24 @@ static void bt_hid_l2cap_intr_disconnected(struct bt_l2cap_chan *chan)
 		return;
 	}
 
+	/* Local request disconnect(INTR channel), and it need to disconnect CTRL channel as well */
+	if (hid->state == BT_HID_STATE_DISCONNECTING) {
+		LOG_DBG("HID disconnect CTRL channel");
+		bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+		return;
+	}
+
+	/* Wait for remote disconnect CTRL channel */
+	if (hid->ctrl_session.br_chan.chan.conn) {
+		LOG_DBG("Wait for remote disconnect CTRL channel");
+		return;
+	}
+
+	if (hid->pending_vc_unplug && hid_cb && hid_cb->vc_unplug) {
+		hid_cb->vc_unplug(hid);
+		hid->pending_vc_unplug = 0;
+	}
+
 	if (hid_cb && hid_cb->disconnected) {
 		hid_cb->disconnected(hid);
 	}
@@ -193,18 +498,101 @@ static void bt_hid_l2cap_intr_disconnected(struct bt_l2cap_chan *chan)
 	bt_hid_deinit(hid);
 }
 
+static int bt_hid_l2cap_ctrl_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_header *hdr;
+	enum bt_hid_session_role role;
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EIO;
+	}
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("HID buf len too short");
+		return -EINVAL;
+	}
+
+	hdr = (struct bt_hid_header *)buf->data;
+	net_buf_pull(buf, sizeof(*hdr));
+
+	role = get_session_role_from_chan(chan);
+	if (role != BT_HID_SESSION_ROLE_CTRL) {
+		LOG_ERR("HID invalid role:%d", role);
+		return -EIO;
+	}
+
+	LOG_DBG("HID CTRL recv type[0x%x] param[0x%x]", hdr->type, hdr->param);
+
+	switch (hdr->type) {
+	case BT_HID_TYPE_CONTROL:
+		hid_control_handle(chan, buf, hdr->param);
+		break;
+	case BT_HID_TYPE_GET_REPORT:
+		hid_get_report_handle(chan, buf, hdr->param);
+		break;
+	case BT_HID_TYPE_SET_REPORT:
+		hid_set_report_handle(chan, buf, hdr->param);
+		break;
+	case BT_HID_TYPE_GET_PROTOCOL:
+		hid_get_protocol_handle(chan, buf, hdr->param);
+		break;
+	case BT_HID_TYPE_SET_PROTOCOL:
+		hid_set_protocol_handle(chan, buf, hdr->param);
+		break;
+	default:
+		struct bt_hid_session *session;
+
+		LOG_ERR("HID type:%d not handle", hdr->type);
+		session = HID_SESSION_BY_CHAN(chan);
+		hid_send_handshake(session, BT_HID_HANDSHAKE_RSP_ERR_UNSUPPORTED_REQ);
+		break;
+	}
+
+	return 0;
+}
+
+static int bt_hid_l2cap_intr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_header *hdr;
+	enum bt_hid_session_role role;
+
+	if (chan == NULL) {
+		LOG_ERR("Invalid hid chan");
+		return -EIO;
+	}
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("HID buf len too short");
+		return -EINVAL;
+	}
+
+	role = get_session_role_from_chan(chan);
+	if (role != BT_HID_SESSION_ROLE_INTR) {
+		LOG_ERR("HID invalid role:%d", role);
+		return -EIO;
+	}
+
+	hdr = (struct bt_hid_header *)buf->data;
+	net_buf_pull(buf, sizeof(*hdr));
+
+	LOG_DBG("HID recv type[0x%x] param[0x%x]", hdr->type, hdr->param);
+
+	return hid_intr_handle(chan, buf, hdr->param);
+}
+
 static void bt_hid_init(struct bt_hid_device *hid, struct bt_conn *conn, enum bt_hid_role role)
 {
 	static const struct bt_l2cap_chan_ops ctrl_ops = {
 		.connected = bt_hid_l2cap_ctrl_connected,
 		.disconnected = bt_hid_l2cap_ctrl_disconnected,
-		.recv = NULL,
+		.recv = bt_hid_l2cap_ctrl_recv,
 	};
 
 	static const struct bt_l2cap_chan_ops intr_ops = {
 		.connected = bt_hid_l2cap_intr_connected,
 		.disconnected = bt_hid_l2cap_intr_disconnected,
-		.recv = NULL,
+		.recv = bt_hid_l2cap_intr_recv,
 	};
 
 	hid->ctrl_session.br_chan.chan.ops = (struct bt_l2cap_chan_ops *)&ctrl_ops;
@@ -266,37 +654,106 @@ static int hid_l2cap_intr_accept(struct bt_conn *conn, struct bt_l2cap_server *s
 	hid->state = BT_HID_STATE_INTR_CONNECTING;
 	*chan = &hid->intr_session.br_chan.chan;
 
+	if (hid_cb && hid_cb->accept) {
+		hid_cb->accept(hid);
+	}
 	return 0;
 }
 
-int bt_hid_device_send_ctrl_data(struct bt_hid_device *hid, uint8_t type, uint8_t *data,
-				 uint16_t len)
+int Z_API(bt_hid_device_send_ctrl_data)(struct bt_hid_device *hid, uint8_t type,
+					 const uint8_t *data, uint16_t len)
 {
-	return -ENOTSUP;
+	__ASSERT_NO_MSG(hid);
+
+	return hid_send_data(&hid->ctrl_session, type, data, len);
 }
 
-int bt_hid_device_send_intr_data(struct bt_hid_device *hid, uint8_t type, uint8_t *data,
-				 uint16_t len)
+int Z_API(bt_hid_device_send_intr_data)(struct bt_hid_device *hid, uint8_t type,
+					 const uint8_t *data, uint16_t len)
 {
-	return -ENOTSUP;
+	__ASSERT_NO_MSG(hid);
+
+	return hid_send_data(&hid->intr_session, type, data, len);
 }
 
-int bt_hid_device_report_error(struct bt_hid_device *hid, uint8_t error)
+int Z_API(bt_hid_device_report_error)(struct bt_hid_device *hid, uint8_t error)
 {
-	return -ENOTSUP;
+	__ASSERT_NO_MSG(hid);
+
+	return hid_send_handshake(&hid->ctrl_session, error);
 }
 
-struct bt_hid_device *bt_hid_device_connect(struct bt_conn *conn)
+struct bt_hid_device *Z_API(bt_hid_device_connect)(struct bt_conn *conn)
 {
-	return NULL;
+	struct bt_hid_device *hid;
+	int err;
+
+	hid = hid_get_connection(conn);
+	if (hid == NULL) {
+		LOG_ERR("Cannot allocate memory");
+		return NULL;
+	}
+
+	if (hid->state != BT_HID_STATE_DISTCONNECTED) {
+		LOG_ERR("HID device is busy, state:%d", hid->state);
+		return NULL;
+	}
+
+	bt_hid_init(hid, conn, BT_HID_ROLE_INITIATOR);
+
+	err = bt_l2cap_chan_connect(conn, &hid->ctrl_session.br_chan.chan, BT_L2CAP_PSM_HID_CTL);
+	if (err != 0) {
+		LOG_WRN("HID connect failed, err:%d", err);
+		return NULL;
+	}
+
+	hid->state = BT_HID_STATE_CTRL_CONNECTING;
+	return hid;
 }
 
-int bt_hid_device_disconnect(struct bt_hid_device *hid)
+int Z_API(bt_hid_device_disconnect)(struct bt_hid_device *hid)
 {
-	return -ENOTSUP;
+	int err;
+
+	__ASSERT_NO_MSG(hid);
+
+	if (hid->state != BT_HID_STATE_CONNECTED) {
+		LOG_ERR("HID device not connected, state:%d", hid->state);
+		return -ENOTCONN;
+	}
+
+	err = bt_l2cap_chan_disconnect(&hid->intr_session.br_chan.chan);
+	if (err != 0) {
+		LOG_WRN("HID disconnect session, err:%d", err);
+		return err;
+	}
+
+	hid->state = BT_HID_STATE_DISCONNECTING;
+	return 0;
 }
 
-int bt_hid_device_register(struct bt_hid_device_cb *cb)
+int Z_API(bt_hid_device_virtual_unplug)(struct bt_hid_device *hid)
+{
+	int err;
+
+	__ASSERT_NO_MSG(hid);
+
+	if (hid->state != BT_HID_STATE_CONNECTED) {
+		LOG_ERR("HID device not connected, state:%d", hid->state);
+		return -ENOTCONN;
+	}
+
+	err = Z_API(bt_hid_device_send_ctrl_data)(hid, BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG, NULL, 0);
+	if (err != 0) {
+		LOG_WRN("HID send vc unplug failed, err:%d", err);
+		return err;
+	}
+
+	hid->pending_vc_unplug = 1;
+	return 0;
+}
+
+int Z_API(bt_hid_device_register)(struct bt_hid_device_cb *cb)
 {
 	LOG_DBG("");
 

--- a/subsys/bluetooth/host/classic/hid_internal.h
+++ b/subsys/bluetooth/host/classic/hid_internal.h
@@ -28,6 +28,9 @@
 #define BT_HID_TYPE_DATAC        0x0b
 
 /* Parameters for Control */
+#define BT_HID_CONTROL_NOP                  0x00
+#define BT_HID_CONTROL_HARD_RESET           0x01
+#define BT_HID_CONTROL_SUSPEND_EXIT         0x02
 #define BT_HID_CONTROL_SUSPEND              0x03
 #define BT_HID_CONTROL_EXIT_SUSPEND         0x04
 #define BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG 0x05


### PR DESCRIPTION
## Summary

This change restores and isolates the Classic Bluetooth HID Device API for the zblue integration.

It:
- Adds the missing HID Device control and data-channel handling for L2CAP.
- Restores HID report, protocol, control, handshake, and virtual-unplug processing.
- Adds the HID connection accept callback.
- Exports HID Device APIs through the `Z_API()` prefix mechanism to avoid symbol collisions with other Bluetooth implementations.
- Applies `const` correctness to HID report input and output buffers.
- Adds API capability macros so users can detect the available HID features at compile time.
- Keeps the changes limited to the zblue Classic HID implementation and public HID header.

## Impact

- Enables the zblue Classic HID Device implementation to provide the expected report and control transactions.
- Prevents unprefixed HID symbols from conflicting with other Bluetooth framework implementations.
- Adds support for virtual cable unplug handling and connection-accept notification.
- Changes HID report callback and send-buffer parameters to use `const` where the implementation does not modify the data.
- Existing users of the unprefixed HID APIs may need to use the corresponding `Z_API()`-expanded names.
- No board-specific configuration, toolchain behavior, or unrelated Bluetooth profiles are changed.
- The change is limited to:
  - `include/zephyr/bluetooth/classic/hid_device.h`
  - `subsys/bluetooth/host/classic/hid_device.c`
  - `subsys/bluetooth/host/classic/hid_internal.h`

## Testing

- Verified the branch is based on `open-vela/external_zblue:dev`.
- Verified the PR contains two commits and only the three intended Classic HID files.
- Ran `git diff --check` successfully.
- Verified the final head commit is:
  `811750c3490cc88b46e9f7a492930ea10a3857dc`
- Full target build and runtime HID interoperability testing were not run in this environment.